### PR TITLE
fix: Remove legacy offset bitmap length test

### DIFF
--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/ConsumerManager.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/ConsumerManager.java
@@ -35,7 +35,8 @@ public class ConsumerManager<K, V> {
             log.debug("Poll completed normally and returned {}...", records.count());
         } catch (WakeupException w) {
             correctPollWakeups++;
-            log.debug("Awoken from broker poll", w);
+            log.debug("Awoken from broker poll");
+            log.trace("Wakeup caller is:", w);
             records = new ConsumerRecords<>(UniMaps.of());
         } finally {
             pollingBroker.set(false);

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/WorkContainer.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/WorkContainer.java
@@ -39,9 +39,13 @@ public class WorkContainer<K, V> implements Comparable<WorkContainer> {
     private int numberOfAttempts;
     private Optional<Instant> failedAt = Optional.empty();
     private boolean inFlight = false;
+
     @Getter
     private Optional<Boolean> userFunctionSucceeded = Optional.empty();
 
+    /**
+     * Wait this long before trying again
+     */
     @Getter
     private static Duration retryDelay = Duration.ofSeconds(10);
 
@@ -133,6 +137,6 @@ public class WorkContainer<K, V> implements Comparable<WorkContainer> {
     @Override
     public String toString() {
 //        return "WorkContainer(" + toTP(cr) + ":" + cr.offset() + ":" + cr.key() + ":" + cr.value() + ")";
-        return "WorkContainer(" + toTP(cr) + ":" + cr.offset() + ":" + cr.key() +")";
+        return "WorkContainer(" + toTP(cr) + ":" + cr.offset() + ":" + cr.key() + ")";
     }
 }

--- a/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/VeryLargeMessageVolumeTest.java
+++ b/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/VeryLargeMessageVolumeTest.java
@@ -4,7 +4,6 @@ package io.confluent.parallelconsumer.integrationTests;
  * Copyright (C) 2020 Confluent, Inc.
  */
 
-import io.confluent.csid.utils.EnumCartesianProductTestSets;
 import io.confluent.csid.utils.StringUtils;
 import io.confluent.csid.utils.TrimListRepresentation;
 import io.confluent.parallelconsumer.ParallelConsumerOptions;
@@ -24,40 +23,33 @@ import org.apache.kafka.common.TopicPartition;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.SoftAssertions;
 import org.awaitility.core.ConditionTimeoutException;
-import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
-import org.junitpioneer.jupiter.CartesianProductTest;
 
 import java.util.*;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 import static io.confluent.parallelconsumer.ParallelConsumerOptions.CommitMode.TRANSACTIONAL_PRODUCER;
-import static io.confluent.parallelconsumer.ParallelConsumerOptions.ProcessingOrder.KEY;
 import static java.time.Duration.ofSeconds;
 import static org.assertj.core.api.Assertions.*;
 import static org.awaitility.Awaitility.waitAtMost;
 import static pl.tlinkowski.unij.api.UniLists.of;
 
 /**
- * Originally created to reproduce bug #25 https://github.com/confluentinc/parallel-consumer/issues/25 which was a known
- * issue with multi threaded use of the {@link org.apache.kafka.clients.producer.KafkaProducer}.
+ * Just a very simple POC-test do demonstrate bitset-too-long exception while running with
+ * very high options.
  * <p>
- * After fixing multi threading issue, using Producer transactions was made optional, and this test grew to uncover
- * several issues with the new implementation of committing offsets through the {@link
- * org.apache.kafka.clients.consumer.KafkaConsumer}.
- *
- * @see io.confluent.parallelconsumer.OffsetCommitter
- * @see io.confluent.parallelconsumer.ConsumerOffsetCommitter
- * @see io.confluent.parallelconsumer.ProducerManager
+ * This fairly consistently occurs in output-log while running and then the consumer shuts down:
+ * <pre>
+ * "Caused by: java.lang.RuntimeException: Bitset too long to encode: 45975. (max: 32767)"
+ * </pre>
+ * https://github.com/confluentinc/parallel-consumer/issues/35
+ * <p>
+ * RuntimeException when running with very high options in 0.2.0.0 (Bitset too long to encode) #35
  */
 @Slf4j
-public class TransactionAndCommitModeTest extends BrokerIntegrationTest<String, String> {
+public class VeryLargeMessageVolumeTest extends BrokerIntegrationTest<String, String> {
 
-    int LOW_MAX_POLL_RECORDS_CONFIG = 1;
-    int DEFAULT_MAX_POLL_RECORDS_CONFIG = 500;
     int HIGH_MAX_POLL_RECORDS_CONFIG = 10_000;
 
     public List<String> consumedKeys = Collections.synchronizedList(new ArrayList<>());
@@ -65,33 +57,10 @@ public class TransactionAndCommitModeTest extends BrokerIntegrationTest<String, 
     public AtomicInteger processedCount = new AtomicInteger(0);
     public AtomicInteger producedCount = new AtomicInteger(0);
 
-    // default
-    @CartesianProductTest(factory = "enumSets")
-    void testDefaultMaxPoll(CommitMode commitMode, ProcessingOrder order) {
-        runTest(DEFAULT_MAX_POLL_RECORDS_CONFIG, commitMode, order);
-    }
 
-    static CartesianProductTest.Sets enumSets() {
-        return new EnumCartesianProductTestSets()
-                .add(CommitMode.class)
-                .add(ProcessingOrder.class);
-    }
-
-    @RepeatedTest(5)
-    public void testTransactionalDefaultMaxPoll() {
-        runTest(DEFAULT_MAX_POLL_RECORDS_CONFIG, TRANSACTIONAL_PRODUCER, KEY);
-    }
-
-    // low
-    @CartesianProductTest(factory = "enumSets")
-    public void testLowMaxPoll(CommitMode commitMode, ProcessingOrder order) {
-        runTest(LOW_MAX_POLL_RECORDS_CONFIG, commitMode, order);
-    }
-
-    // high counts
-    @CartesianProductTest(factory = "enumSets")
-    public void testHighMaxPollEnum(CommitMode commitMode, ProcessingOrder order) {
-        runTest(HIGH_MAX_POLL_RECORDS_CONFIG, commitMode, order);
+    @Test
+    public void shouldNotThrowBitsetTooLongException() {
+        runTest(HIGH_MAX_POLL_RECORDS_CONFIG, CommitMode.CONSUMER_ASYNCHRONOUS, ProcessingOrder.UNORDERED);
     }
 
     @SneakyThrows
@@ -101,7 +70,7 @@ public class TransactionAndCommitModeTest extends BrokerIntegrationTest<String, 
 
         // pre-produce messages to input-topic
         List<String> expectedKeys = new ArrayList<>();
-        int expectedMessageCount = 1000;
+        int expectedMessageCount = 1_000_000;
         log.info("Producing {} messages before starting test", expectedMessageCount);
         List<Future<RecordMetadata>> sends = new ArrayList<>();
         try (Producer<String, String> kafkaProducer = kcu.createNewProducer(false)) {
@@ -137,6 +106,9 @@ public class TransactionAndCommitModeTest extends BrokerIntegrationTest<String, 
                 .consumer(newConsumer)
                 .producer(newProducer)
                 .commitMode(commitMode)
+                .numberOfThreads(100)
+                .maxNumberMessagesBeyondBaseCommitOffset(10_000)
+                .maxMessagesToQueue(10_000)
                 .build());
         pc.subscribe(of(inputName));
 
@@ -164,7 +136,8 @@ public class TransactionAndCommitModeTest extends BrokerIntegrationTest<String, 
         var failureMessage = StringUtils.msg("All keys sent to input-topic should be processed and produced, within time (expected: {} commit: {} order: {} max poll: {})",
                 expectedMessageCount, commitMode, order, maxPoll);
         try {
-            waitAtMost(ofSeconds(20)).alias(failureMessage).untilAsserted(() -> {
+            waitAtMost(ofSeconds(200))
+                    .alias(failureMessage).untilAsserted(() -> {
                 log.info("Processed-count: {}, Produced-count: {}", processedCount.get(), producedCount.get());
                 SoftAssertions all = new SoftAssertions();
                 all.assertThat(new ArrayList<>(consumedKeys)).as("all expected are consumed").hasSameSizeAs(expectedKeys);
@@ -172,11 +145,6 @@ public class TransactionAndCommitModeTest extends BrokerIntegrationTest<String, 
                 all.assertAll();
             });
         } catch (ConditionTimeoutException e) {
-            log.debug("Expected keys (size {})", expectedKeys.size());
-            log.debug("Consumed keys ack'd (size {})", consumedKeys.size());
-            log.debug("Produced keys (size {})", producedKeysAcknowledged.size());
-            expectedKeys.removeAll(consumedKeys);
-            log.info("Missing keys from consumed: {}", expectedKeys);
             fail(failureMessage + "\n" + e.getMessage());
         }
 
@@ -190,24 +158,5 @@ public class TransactionAndCommitModeTest extends BrokerIntegrationTest<String, 
         assertThat(expectedMessageCount).isEqualTo(processedCount.get());
         assertThat(producedKeysAcknowledged).hasSameSizeAs(expectedKeys);
     }
-
-    @Test
-    void customRepresentationFail() {
-        List<Integer> one = IntStream.range(0, 1000).boxed().collect(Collectors.toList());
-        List<Integer> two = IntStream.range(999, 2000).boxed().collect(Collectors.toList());
-        assertThatThrownBy(() -> assertThat(one).withRepresentation(new TrimListRepresentation()).containsAll(two))
-                .hasMessageContaining("trimmed");
-    }
-
-    @Test
-    void customRepresentationPass() {
-        Assertions.useRepresentation(new TrimListRepresentation());
-        List<Integer> one = IntStream.range(0, 1000).boxed().collect(Collectors.toList());
-        List<Integer> two = IntStream.range(0, 1000).boxed().collect(Collectors.toList());
-        SoftAssertions all = new SoftAssertions();
-        all.assertThat(one).containsAll(two);
-        all.assertAll();
-    }
-
 
 }

--- a/parallel-consumer-core/src/test/java/io/confluent/csid/utils/TrimListRepresentation.java
+++ b/parallel-consumer-core/src/test/java/io/confluent/csid/utils/TrimListRepresentation.java
@@ -1,0 +1,53 @@
+package io.confluent.csid.utils;
+
+import lombok.extern.slf4j.Slf4j;
+import org.assertj.core.presentation.StandardRepresentation;
+import org.testcontainers.shaded.com.google.common.collect.Lists;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collectors;
+
+/**
+ * Trims long lists to make large List assertions more readable
+ */
+@Slf4j
+public class TrimListRepresentation extends StandardRepresentation {
+
+    private final int sizeLimit = 10;
+
+    protected static String msg = "Collection has been trimmed...";
+
+    @Override
+    public String toStringOf(Object o) {
+        if (o instanceof Set) {
+            Set aSet = (Set) o;
+            if (aSet.size() > sizeLimit)
+                o = aSet.stream().collect(Collectors.toList());
+        }
+        if (o instanceof Object[]) {
+            Object[] anObjectArray = (Object[]) o;
+            if (anObjectArray.length > sizeLimit)
+                o = Arrays.stream(anObjectArray).collect(Collectors.toList());
+        }
+        if (o instanceof String[]) {
+            Object[] anObjectArray = (Object[]) o;
+            if (anObjectArray.length > sizeLimit)
+                o = Arrays.stream(anObjectArray).collect(Collectors.toList());
+        }
+        if (o instanceof List) {
+            List<?> aList = (List<?>) o;
+            if (aList.size() > sizeLimit) {
+                log.trace("List too long ({}), trimmed...", aList.size());
+                List trimmedListView = aList.subList(0, sizeLimit);
+                // don't mutate backing lists
+                CopyOnWriteArrayList copy = Lists.newCopyOnWriteArrayList(trimmedListView);
+                copy.add(msg);
+                return super.toStringOf(copy);
+            }
+        }
+        return super.toStringOf(o);
+    }
+}


### PR DESCRIPTION
Fixes #35 RuntimeException when running with very high options in 0.2.0.0 (Bitset too long to encode) #35

Was left over from old code, before WorkManager#maybeStripOffsetPayload was added
