### PR TITLE
Fix for Bug 62 skip record on restart - off by one one?

### DIFF
--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/WorkManager.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/WorkManager.java
@@ -414,6 +414,7 @@ public class WorkManager<K, V> implements ConsumerRebalanceListener {
                         // this state should never happen
                         log.debug("Work is in queue with stale epoch. Will remove now. Was it not removed properly on revoke? Or are we in a race state? {}", workContainer);
                         staleWorkToRemove.add(workContainer);
+                        continue; // skip
                     }
                 }
 

--- a/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/OffsetCommittingSanityTest.java
+++ b/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/OffsetCommittingSanityTest.java
@@ -1,0 +1,113 @@
+package io.confluent.parallelconsumer.integrationTests;
+
+import io.confluent.parallelconsumer.ParallelConsumerOptions;
+import io.confluent.parallelconsumer.ParallelEoSStreamProcessor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.api.Test;
+import pl.tlinkowski.unij.api.UniLists;
+import pl.tlinkowski.unij.api.UniSets;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static java.time.Duration.ofSeconds;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.waitAtMost;
+
+/**
+ * Test offset restoring from boundary conditions, i.e. when no offset data is encoded in metadata
+ *
+ * Reproduces issue 62: https://github.com/confluentinc/parallel-consumer/issues/62
+ *
+ * @see io.confluent.parallelconsumer.ParallelEoSStreamProcessorTest#closeOpenBoundaryCommits
+ */
+@Slf4j
+class OffsetCommittingSanityTest extends BrokerIntegrationTest<String, String> {
+
+    @Test
+    void shouldNotSkipAnyMessagesOnRestartRoot() throws Exception {
+        setupTopic("foo");
+        List<Long> producedOffsets = new ArrayList<>();
+        List<Long> consumedOffsets = new ArrayList<>();
+
+        var kafkaProducer = kcu.createNewProducer(false);
+
+        // offset 0
+        sendCheckClose(producedOffsets, consumedOffsets, kafkaProducer, "key-0", "value-0", true);
+
+        assertCommittedOffset(1);
+
+        // offset 1
+        sendCheckClose(producedOffsets, consumedOffsets, kafkaProducer, "key-1", "value-1", true);
+
+        assertCommittedOffset(2);
+
+        // sanity
+        assertThat(producedOffsets).containsExactly(0L, 1L);
+        assertThat(consumedOffsets).containsExactly(0L, 1L);
+    }
+
+    @Test
+    void shouldNotSkipAnyMessagesOnRestartAsDescribed() throws Exception {
+        setupTopic("foo");
+        List<Long> producedOffsets = new ArrayList<>();
+        List<Long> consumedOffsets = new ArrayList<>();
+
+        var kafkaProducer = kcu.createNewProducer(false);
+
+        // offset 0
+        sendCheckClose(producedOffsets, consumedOffsets, kafkaProducer, "key-0", "value-0", true);
+
+        assertCommittedOffset(1);
+
+        // offset 1
+        sendCheckClose(producedOffsets, consumedOffsets, kafkaProducer, "key-1", "value-1", false);
+
+        // offset 2
+        sendCheckClose(producedOffsets, consumedOffsets, kafkaProducer, "key-2", "value-2", true);
+    }
+
+    private void sendCheckClose(List<Long> producedOffsets,
+                                List<Long> consumedOffsets,
+                                KafkaProducer<Object, Object> kafkaProducer,
+                                String key, String val,
+                                boolean check) throws Exception {
+        producedOffsets.add(kafkaProducer.send(new ProducerRecord<>(topic, key, val)).get().offset());
+        var newConsumer = kcu.createNewConsumer(false);
+        var pc = createParallelConsumer(topic, newConsumer);
+        pc.poll(consumerRecord -> consumedOffsets.add(consumerRecord.offset()));
+        if (check) {
+            waitAtMost(ofSeconds(1)).alias("all produced messages consumed")
+                    .untilAsserted(() -> assertThat(consumedOffsets).isEqualTo(producedOffsets));
+        } else {
+            Thread.sleep(2000);
+        }
+        pc.closeDrainFirst();
+    }
+
+    private void assertCommittedOffset(long expectedOffset) {
+        // assert committed offset
+        var newConsumer = kcu.createNewConsumer(false);
+        newConsumer.subscribe(UniSets.of(topic));
+        newConsumer.poll(ofSeconds(1));
+        Map<TopicPartition, OffsetAndMetadata> committed = newConsumer.committed(newConsumer.assignment());
+        assertThat(committed.get(new TopicPartition(topic, 0)).offset()).isEqualTo(expectedOffset);
+        newConsumer.close();
+    }
+
+    private ParallelEoSStreamProcessor<String, String> createParallelConsumer(String topicName, Consumer consumer) {
+        ParallelEoSStreamProcessor<String, String> pc = new ParallelEoSStreamProcessor<>(ParallelConsumerOptions.builder()
+                .consumer(consumer)
+                .build()
+        );
+        pc.subscribe(UniLists.of(topicName));
+        return pc;
+    }
+
+}

--- a/parallel-consumer-core/src/test/java/io/confluent/parallelconsumer/ParallelEoSStreamProcessorTest.java
+++ b/parallel-consumer-core/src/test/java/io/confluent/parallelconsumer/ParallelEoSStreamProcessorTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
+import pl.tlinkowski.unij.api.UniLists;
 
 import java.time.Duration;
 import java.util.*;
@@ -37,6 +38,7 @@ import static java.time.Duration.ofSeconds;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.*;
 import static org.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.waitAtMost;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 import static org.mockito.internal.verification.VerificationModeFactory.times;
@@ -297,7 +299,7 @@ public class ParallelEoSStreamProcessorTest extends ParallelEoSStreamProcessorTe
         parallelConsumer.requestCommitAsap();
 
         waitForOneLoopCycle();
-        if(isUsingAsyncCommits())
+        if (isUsingAsyncCommits())
             waitForSomeLoopCycles(3); // async commit can be slow - todo change this to event based
 
         // make sure offset 0 and 1 is committed
@@ -801,5 +803,6 @@ public class ParallelEoSStreamProcessorTest extends ParallelEoSStreamProcessorTe
         parallelConsumer.requestCommitAsap();
         waitForSomeLoopCycles(2);
     }
+
 }
 


### PR DESCRIPTION
Fixes #62 - the off by one issue would cause first message to be skipped in some situations