### PR TITLE
Reduce log-level if no results are returned from user-function

### DIFF
--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/ParallelEoSStreamProcessor.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/ParallelEoSStreamProcessor.java
@@ -360,7 +360,7 @@ public class ParallelEoSStreamProcessor<K, V> implements ParallelStreamProcessor
             List<ProducerRecord<K, V>> recordListToProduce = carefullyRun(userFunction, consumedRecord);
 
             if (recordListToProduce.isEmpty()) {
-                log.warn("No result returned from function to send.");
+                log.debug("No result returned from function to send.");
             }
             log.trace("asyncPoll and Stream - Consumed a record ({}), and returning a derivative result record to be produced: {}", consumedRecord, recordListToProduce);
 


### PR DESCRIPTION
Have some cases where it's natural to not produce any records, so reducing the log-level for this situation.