### PR TITLE
Upgrade to Awaitility fail fast feature now that it's merged and released

### DIFF
--- a/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/MultiInstanceHighVolumeTest.java
+++ b/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/MultiInstanceHighVolumeTest.java
@@ -81,7 +81,9 @@ class MultiInstanceHighVolumeTest extends BrokerIntegrationTest<String, String> 
                 expectedMessageCount, commitMode, order, maxPoll);
         try {
             waitAtMost(ofSeconds(60))
-//                    .failFast(() -> pcThree.isClosedOrFailed(), () -> pcThree.getFailureCause()) // requires https://github.com/awaitility/awaitility/issues/178#issuecomment-734769761
+                    // dynamic reason support still waiting https://github.com/awaitility/awaitility/pull/193#issuecomment-873116199
+                    // .failFast( () -> pcThree.getFailureCause(), () -> pcThree.isClosedOrFailed()) // requires https://github.com/awaitility/awaitility/issues/178#issuecomment-734769761
+                    .failFast("PC died - check logs", () -> pcThree.isClosedOrFailed()) // requires https://github.com/awaitility/awaitility/issues/178#issuecomment-734769761
                     .alias(failureMessage)
                     .pollInterval(1, SECONDS)
                     .untilAsserted(() -> {

--- a/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/MultiInstanceRebalanceTest.java
+++ b/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/MultiInstanceRebalanceTest.java
@@ -128,7 +128,9 @@ public class MultiInstanceRebalanceTest extends BrokerIntegrationTest<String, St
         ProgressTracker progressTracker = new ProgressTracker(count);
         try {
             waitAtMost(ofSeconds(30))
-//                    .failFast(() -> pc1.isClosedOrFailed(), () -> pc1.getFailureCause()) // requires https://github.com/awaitility/awaitility/issues/178#issuecomment-734769761
+                    // dynamic reason support still waiting https://github.com/awaitility/awaitility/pull/193#issuecomment-873116199
+                    // .failFast( () -> pc1.getFailureCause(), () -> pc1.isClosedOrFailed()) // requires https://github.com/awaitility/awaitility/issues/178#issuecomment-734769761
+                    .failFast("PC died - check logs", () -> pc1.getParallelConsumer().isClosedOrFailed()) // requires https://github.com/awaitility/awaitility/issues/178#issuecomment-734769761
                     .alias(failureMessage)
                     .pollInterval(1, SECONDS)
                     .untilAsserted(() -> {

--- a/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/TransactionAndCommitModeTest.java
+++ b/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/TransactionAndCommitModeTest.java
@@ -209,8 +209,10 @@ public class TransactionAndCommitModeTest extends BrokerIntegrationTest<String, 
                 expectedMessageCount, commitMode, order, maxPoll);
         try {
             waitAtMost(ofSeconds(2000))
-//                    .failFast(() -> pc.isClosedOrFailed() // needs fail-fast feature in 4.0.4 - https://github.com/awaitility/awaitility/pull/193
-//                                    || producedCount.get() > expectedMessageCount,
+                    // dynamic reason support still waiting https://github.com/awaitility/awaitility/pull/193#issuecomment-873116199
+                    .failFast("PC died, check logs.",
+                            () -> pc.isClosedOrFailed() // needs fail-fast feature in 4.0.4 - https://github.com/awaitility/awaitility/pull/193
+                                    || producedCount.get() > expectedMessageCount)
 //                            () -> {
 //                                if (pc.isClosedOrFailed())
 //                                    return pc.getFailureCause();

--- a/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/VeryLargeMessageVolumeTest.java
+++ b/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/VeryLargeMessageVolumeTest.java
@@ -164,7 +164,9 @@ public class VeryLargeMessageVolumeTest extends BrokerIntegrationTest<String, St
                 expectedMessageCount, commitMode, order, maxPoll);
         try {
             waitAtMost(ofSeconds(120))
-//                    .failFast(() -> pc.isClosedOrFailed(), () -> pc.getFailureCause()) // requires https://github.com/awaitility/awaitility/issues/178#issuecomment-734769761
+                    // dynamic reason support still waiting https://github.com/awaitility/awaitility/pull/193#issuecomment-873116199
+                    .failFast("PC died - check logs", pc::isClosedOrFailed)
+                    //, () -> pc.getFailureCause()) // requires https://github.com/awaitility/awaitility/issues/178#issuecomment-734769761
                     .alias(failureMessage)
                     .pollInterval(1, SECONDS)
                     .untilAsserted(() -> {

--- a/parallel-consumer-core/src/test/java/io/confluent/csid/utils/LongPollingMockConsumer.java
+++ b/parallel-consumer-core/src/test/java/io/confluent/csid/utils/LongPollingMockConsumer.java
@@ -3,6 +3,7 @@ package io.confluent.csid.utils;
 /*-
  * Copyright (C) 2020-2021 Confluent, Inc.
  */
+
 import lombok.Getter;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;

--- a/parallel-consumer-core/src/test/java/io/confluent/parallelconsumer/OffsetEncodingBackPressureTest.java
+++ b/parallel-consumer-core/src/test/java/io/confluent/parallelconsumer/OffsetEncodingBackPressureTest.java
@@ -92,7 +92,9 @@ public class OffsetEncodingBackPressureTest extends ParallelEoSStreamProcessorTe
         // wait for all pre-produced messages to be processed and produced
         Assertions.useRepresentation(new TrimListRepresentation());
         waitAtMost(ofSeconds(120))
-//                .failFast(() -> parallelConsumer.isClosedOrFailed(), () -> parallelConsumer.getFailureCause()) // requires https://github.com/awaitility/awaitility/issues/178#issuecomment-734769761
+                // dynamic reason support still waiting https://github.com/awaitility/awaitility/pull/193#issuecomment-873116199
+                .failFast("PC died - check logs", parallelConsumer::isClosedOrFailed)
+                //, () -> parallelConsumer.getFailureCause()) // requires https://github.com/awaitility/awaitility/issues/178#issuecomment-734769761
                 .pollInterval(1, SECONDS)
                 .untilAsserted(() -> {
                     assertThat(processedCount.get()).isEqualTo(99L);

--- a/parallel-consumer-core/src/test/resources/junit-platform.properties
+++ b/parallel-consumer-core/src/test/resources/junit-platform.properties
@@ -5,5 +5,5 @@
 # This seems to break some aspects of Ideas test tracking system (i.e. replay failures)
 #junit.jupiter.displayname.generator.default = io.confluent.csid.utils.ReplaceCamelCase
 
-junit.jupiter.execution.parallel.enabled = true
-junit.jupiter.execution.parallel.mode.default = concurrent
+junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.mode.default=concurrent

--- a/pom.xml
+++ b/pom.xml
@@ -340,7 +340,7 @@
             <dependency>
                 <groupId>org.awaitility</groupId>
                 <artifactId>awaitility</artifactId>
-                <version>4.0.3</version>
+                <version>4.1.0</version>
                 <scope>test</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
See https://github.com/awaitility/awaitility/pull/193
Enables awaitility to fail much faster if the PC has died for some reason, causing no progress to be made, having to wait for the full Awaitility timeout to expire.