### PR TITLE
fix: #99 Don't allow use of core methods from the vert.x or reactor module

### DIFF
--- a/parallel-consumer-vertx/src/main/java/io/confluent/parallelconsumer/vertx/VertxParallelEoSStreamProcessor.java
+++ b/parallel-consumer-vertx/src/main/java/io/confluent/parallelconsumer/vertx/VertxParallelEoSStreamProcessor.java
@@ -290,7 +290,7 @@ public class VertxParallelEoSStreamProcessor<K, V> extends ParallelEoSStreamProc
 
     private void blockInvalidCoreMethodUse() {
         throw new IllegalStateException("Can't use core methods from vert.x module. \n" +
-                "Throwing an exception here is ATM easier then doing the full vert.s base class refactor (https://github.com/confluentinc/parallel-consumer/pull/133) \n" +
+                "Throwing an exception here is ATM easier then doing the full vert.x base class refactor (https://github.com/confluentinc/parallel-consumer/pull/133) \n" +
                 "Use the core module directly instead. See https://github.com/confluentinc/parallel-consumer/issues/99");
     }
 

--- a/parallel-consumer-vertx/src/main/java/io/confluent/parallelconsumer/vertx/VertxParallelEoSStreamProcessor.java
+++ b/parallel-consumer-vertx/src/main/java/io/confluent/parallelconsumer/vertx/VertxParallelEoSStreamProcessor.java
@@ -22,6 +22,7 @@ import lombok.Setter;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.utils.Time;
 import pl.tlinkowski.unij.api.UniLists;
 import pl.tlinkowski.unij.api.UniMaps;
@@ -282,4 +283,34 @@ public class VertxParallelEoSStreamProcessor<K, V> extends ParallelEoSStreamProc
         }
     }
 
+    @Override
+    public void poll(Consumer<ConsumerRecord<K, V>> usersVoidConsumptionFunction) {
+        blockInvalidCoreMethodUse();
+    }
+
+    private void blockInvalidCoreMethodUse() {
+        throw new IllegalStateException("Can't use core methods from vert.x module. \n" +
+                "Throwing an exception here is ATM easier then doing the full vert.s base class refactor (https://github.com/confluentinc/parallel-consumer/pull/133) \n" +
+                "Use the core module directly instead. See https://github.com/confluentinc/parallel-consumer/issues/99");
+    }
+
+    @Override
+    public void pollAndProduceMany(Function<ConsumerRecord<K, V>, List<ProducerRecord<K, V>>> userFunction, Consumer<ConsumeProduceResult<K, V, K, V>> callback) {
+        blockInvalidCoreMethodUse();
+    }
+
+    @Override
+    public void pollAndProduceMany(Function<ConsumerRecord<K, V>, List<ProducerRecord<K, V>>> userFunction) {
+        blockInvalidCoreMethodUse();
+    }
+
+    @Override
+    public void pollAndProduce(Function<ConsumerRecord<K, V>, ProducerRecord<K, V>> userFunction) {
+        blockInvalidCoreMethodUse();
+    }
+
+    @Override
+    public void pollAndProduce(Function<ConsumerRecord<K, V>, ProducerRecord<K, V>> userFunction, Consumer<ConsumeProduceResult<K, V, K, V>> callback) {
+        blockInvalidCoreMethodUse();
+    }
 }

--- a/parallel-consumer-vertx/src/test/java/io/confluent/parallelconsumer/vertx/VertxTest.java
+++ b/parallel-consumer-vertx/src/test/java/io/confluent/parallelconsumer/vertx/VertxTest.java
@@ -42,6 +42,7 @@ import static io.confluent.csid.utils.LatchTestUtils.awaitLatch;
 import static io.confluent.parallelconsumer.ParallelConsumerOptions.CommitMode.PERIODIC_TRANSACTIONAL_PRODUCER;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.awaitility.Awaitility.await;
 import static pl.tlinkowski.unij.api.UniLists.of;
 
@@ -245,6 +246,16 @@ class VertxTest extends ParallelEoSStreamProcessorTestBase {
         if (!success)
             throw new AssertionError("Timeout reached");
         return list;
+    }
+
+    @Test
+    void coreMethodsBlocked() {
+        assertThatCode(() ->
+                parallelConsumer.poll(stringStringConsumerRecord -> {
+                    //ignore
+                }))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("core", "methods");
     }
 
 }


### PR DESCRIPTION
The threading system for the vert.x module is not compatible with the core module. Use the core module directly instead.

Partial temp fix for #99