### PR TITLE
build: Crank up Enforcer and turn on ossindex audit

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -30,7 +30,6 @@
 // leave it commented out when committing work)
 //:project_root: ../../
 
-note: {docdir}
 
 ifdef::env-github[]
 :tip-caption: :bulb:
@@ -1150,6 +1149,20 @@ http://www.apache.org/[Apache®], http://kafka.apache.org/[Apache Kafka], and ht
 ifndef::github_name[]
 toc::[]
 endif::[]
+
+== Next Version
+
+=== Features
+
+* PollContext API - provides central access to result set with various convenience methods as well as metadata about records, such as failure count
+* Batching - all API methods now support batching.
+See the Options class set batch size for more information.
+
+=== Fixes and Improvements
+
+* Event system - better CPU usage in control thread
+* Concurrency stability improvements
+* Update dependencies
 
 == v0.4.0.0
 // https://github.com/confluentinc/parallel-consumer/releases/tag/0.4.0.0

--- a/pom.xml
+++ b/pom.xml
@@ -441,6 +441,20 @@
         </testResources>
         <plugins>
             <plugin>
+                <groupId>org.sonatype.ossindex.maven</groupId>
+                <artifactId>ossindex-maven-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <id>audit-dependencies</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>audit</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>com.soebes.maven.plugins</groupId>
                 <artifactId>echo-maven-plugin</artifactId>
                 <version>0.5.0</version>
@@ -627,10 +641,11 @@
                 <version>3.0.0</version>
                 <executions>
                     <execution>
-                        <id>enforce-java</id>
+                        <id>enforce-versions</id>
                         <goals>
                             <goal>enforce</goal>
                         </goals>
+                        <phase>validate</phase>
                         <configuration>
                             <rules>
                                 <requireJavaVersion>
@@ -639,6 +654,32 @@
                                 <requireMavenVersion>
                                     <version>3.6.3</version>
                                 </requireMavenVersion>
+                                <requireMavenVersion>
+                                    <version>3.6.3</version>
+                                </requireMavenVersion>
+                                <bannedDependencies>
+                                    <searchTransitive>true</searchTransitive>
+                                    <excludes>
+                                        <exclude>log4j:*:*:*:runtime</exclude>
+                                        <exclude>log4j:*:*:*:compile</exclude>
+                                        <exclude>log4j:*:*:*:test</exclude>
+                                        <exclude>org.apache.logging.log4j:log4j-core:*:*:runtime</exclude>
+                                        <exclude>org.apache.logging.log4j:log4j-core:*:*:compile</exclude>
+                                        <!-- Javafaker is abandoned and has CVEs and bugs -->
+                                        <exclude>com.github.javafaker</exclude>
+                                    </excludes>
+                                </bannedDependencies>
+                                <reactorModuleConvergence/>
+                                <banDuplicatePomDependencyVersions/>
+                                <requireSameVersions/>
+                                <requireReleaseDeps>
+                                    <onlyWhenRelease>false</onlyWhenRelease>
+                                    <failWhenParentIsSnapshot>false</failWhenParentIsSnapshot>
+                                    <excludes>
+                                        <exclude>io.confluent.parallelconsumer:</exclude>
+                                    </excludes>
+                                </requireReleaseDeps>
+                                <requirePluginVersions/>
                             </rules>
                         </configuration>
                     </execution>
@@ -767,6 +808,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.2.0</version>
                 <executions>
                     <execution>
                         <phase>initialize</phase>


### PR DESCRIPTION
Was blocked by dependably upgrades:
- [x]  #227
