### PR TITLE
refactor: Separate producer and consumer props

### DIFF
--- a/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/BrokerIntegrationTest.java
+++ b/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/BrokerIntegrationTest.java
@@ -1,8 +1,7 @@
-
+package io.confluent.parallelconsumer.integrationTests;
 /*-
  * Copyright (C) 2020-2022 Confluent, Inc.
  */
-package io.confluent.parallelconsumer.integrationTests;
 
 import io.confluent.csid.testcontainers.FilteredTestContainerSlf4jLogConsumer;
 import io.confluent.parallelconsumer.integrationTests.utils.KafkaClientUtils;

--- a/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/BrokerIntegrationTest.java
+++ b/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/BrokerIntegrationTest.java
@@ -1,3 +1,7 @@
+
+/*-
+ * Copyright (C) 2020-2022 Confluent, Inc.
+ */
 package io.confluent.parallelconsumer.integrationTests;
 
 /*-
@@ -87,7 +91,7 @@ public abstract class BrokerIntegrationTest<K, V> {
 
     protected void ensureTopic(String topic, int numPartitions) {
         NewTopic e1 = new NewTopic(topic, numPartitions, (short) 1);
-        CreateTopicsResult topics = kcu.admin.createTopics(UniLists.of(e1));
+        CreateTopicsResult topics = kcu.getAdmin().createTopics(UniLists.of(e1));
         try {
             Void all = topics.all().get();
         } catch (ExecutionException e) {

--- a/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/BrokerIntegrationTest.java
+++ b/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/BrokerIntegrationTest.java
@@ -4,10 +4,6 @@
  */
 package io.confluent.parallelconsumer.integrationTests;
 
-/*-
- * Copyright (C) 2020-2021 Confluent, Inc.
- */
-
 import io.confluent.csid.testcontainers.FilteredTestContainerSlf4jLogConsumer;
 import io.confluent.parallelconsumer.integrationTests.utils.KafkaClientUtils;
 import lombok.extern.slf4j.Slf4j;

--- a/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/CloseAndOpenOffsetTest.java
+++ b/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/CloseAndOpenOffsetTest.java
@@ -1,11 +1,6 @@
-
+package io.confluent.parallelconsumer.integrationTests;
 /*-
  * Copyright (C) 2020-2022 Confluent, Inc.
- */
-package io.confluent.parallelconsumer.integrationTests;
-
-/*-
- * Copyright (C) 2020-2021 Confluent, Inc.
  */
 
 import io.confluent.csid.utils.Range;

--- a/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/CloseAndOpenOffsetTest.java
+++ b/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/CloseAndOpenOffsetTest.java
@@ -244,7 +244,8 @@ public class CloseAndOpenOffsetTest extends BrokerIntegrationTest<String, String
         setupTopic();
 
         // send a single message
-        kcu.getProducer().send(new ProducerRecord<>(topic, "0", "0"));
+        String expectedPayload = "0";
+        kcu.getProducer().send(new ProducerRecord<>(topic, expectedPayload, expectedPayload));
 
         KafkaConsumer<String, String> consumer = kcu.createNewConsumer();
         KafkaProducer<String, String> producerOne = kcu.createNewProducer(true);
@@ -268,7 +269,7 @@ public class CloseAndOpenOffsetTest extends BrokerIntegrationTest<String, String
             // the single message is processed
             await().untilAsserted(() -> assertThat(readByOne)
                     .extracting(ConsumerRecord::value)
-                    .containsExactly("0"));
+                    .containsExactly(expectedPayload));
 
         } finally {
             log.debug("asyncOne closed");

--- a/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/CloseAndOpenOffsetTest.java
+++ b/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/CloseAndOpenOffsetTest.java
@@ -40,6 +40,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 
+import static io.confluent.parallelconsumer.AbstractParallelEoSStreamProcessorTestBase.defaultTimeout;
 import static io.confluent.parallelconsumer.ParallelConsumerOptions.CommitMode.PERIODIC_TRANSACTIONAL_PRODUCER;
 import static io.confluent.parallelconsumer.ParallelConsumerOptions.ProcessingOrder.UNORDERED;
 import static java.time.Duration.ofMillis;
@@ -348,7 +349,7 @@ public class CloseAndOpenOffsetTest extends BrokerIntegrationTest<String, String
             });
 
             // the single message is not processed
-            await().atMost(ofSeconds(10)).untilAsserted(() -> assertThat(readByOne.size())
+            await().atMost(defaultTimeout).untilAsserted(() -> assertThat(readByOne.size())
                     .isEqualTo(quantity - numberOfFailingMessages));
 
             //

--- a/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/KafkaSanityTests.java
+++ b/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/KafkaSanityTests.java
@@ -4,10 +4,6 @@
  */
 package io.confluent.parallelconsumer.integrationTests;
 
-/*-
- * Copyright (C) 2020-2021 Confluent, Inc.
- */
-
 import io.confluent.parallelconsumer.offsets.OffsetMapCodecManager;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.RandomStringUtils;

--- a/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/KafkaSanityTests.java
+++ b/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/KafkaSanityTests.java
@@ -1,8 +1,7 @@
-
+package io.confluent.parallelconsumer.integrationTests;
 /*-
  * Copyright (C) 2020-2022 Confluent, Inc.
  */
-package io.confluent.parallelconsumer.integrationTests;
 
 import io.confluent.parallelconsumer.offsets.OffsetMapCodecManager;
 import lombok.extern.slf4j.Slf4j;

--- a/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/KafkaSanityTests.java
+++ b/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/KafkaSanityTests.java
@@ -1,3 +1,7 @@
+
+/*-
+ * Copyright (C) 2020-2022 Confluent, Inc.
+ */
 package io.confluent.parallelconsumer.integrationTests;
 
 /*-
@@ -39,7 +43,7 @@ public class KafkaSanityTests extends BrokerIntegrationTest<String, String> {
     public void pausedConsumerStillLongPollsForNothing() {
         log.info("Setup topic");
         setupTopic();
-        KafkaConsumer<String, String> consumer = kcu.consumer;
+        KafkaConsumer<String, String> consumer = kcu.getConsumer();
         log.info("Subscribe to topic");
         consumer.subscribe(UniLists.of(topic));
         Set<TopicPartition> assignment = consumer.assignment();
@@ -79,7 +83,7 @@ public class KafkaSanityTests extends BrokerIntegrationTest<String, String> {
                 .as("approximate sanity - ensure start state settings (shared static state :`( )")
                 .isGreaterThan(3000);
 
-        KafkaConsumer<String, String> consumer = kcu.consumer;
+        KafkaConsumer<String, String> consumer = kcu.getConsumer();
         TopicPartition tpOne = new TopicPartition(topic, 0);
         TopicPartition tpTwo = new TopicPartition(topic, 1);
         HashMap<TopicPartition, OffsetAndMetadata> map = new HashMap<>();

--- a/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/LoadTest.java
+++ b/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/LoadTest.java
@@ -1,3 +1,7 @@
+
+/*-
+ * Copyright (C) 2020-2022 Confluent, Inc.
+ */
 package io.confluent.parallelconsumer.integrationTests;
 
 /*-
@@ -61,7 +65,7 @@ public class LoadTest extends DbTest {
     void timedNormalKafkaConsumerTest() {
         setupTestData();
         // subscribe in advance, it can be a few seconds
-        kcu.consumer.subscribe(UniLists.of(topic));
+        kcu.getConsumer().subscribe(UniLists.of(topic));
 
         readRecordsPlainConsumer(total, topic);
     }
@@ -128,7 +132,7 @@ public class LoadTest extends DbTest {
 
             Executors.newCachedThreadPool().submit(() -> {
                 while (allRecords.size() < total) {
-                    ConsumerRecords<String, String> poll = kcu.consumer.poll(ofMillis(500));
+                    ConsumerRecords<String, String> poll = kcu.getConsumer().poll(ofMillis(500));
                     log.info("Polled batch of {} messages", poll.count());
 
                     //save
@@ -177,7 +181,7 @@ public class LoadTest extends DbTest {
                 String value = RandomStringUtils.randomAlphabetic(messageSizeInBytes);
                 var producerRecord = new ProducerRecord<>(topic, key, value);
                 try {
-                    var meta = kcu.producer.send(producerRecord);
+                    var meta = kcu.getProducer().send(producerRecord);
                     futureMetadataResultsFromPublishing.add(meta);
                 } catch (Exception e) {
                     throw new RuntimeException(e);

--- a/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/LoadTest.java
+++ b/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/LoadTest.java
@@ -4,10 +4,6 @@
  */
 package io.confluent.parallelconsumer.integrationTests;
 
-/*-
- * Copyright (C) 2020-2021 Confluent, Inc.
- */
-
 import io.confluent.csid.utils.ProgressBarUtils;
 import io.confluent.parallelconsumer.ParallelConsumerOptions;
 import io.confluent.parallelconsumer.ParallelEoSStreamProcessor;

--- a/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/LoadTest.java
+++ b/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/LoadTest.java
@@ -1,8 +1,7 @@
-
+package io.confluent.parallelconsumer.integrationTests;
 /*-
  * Copyright (C) 2020-2022 Confluent, Inc.
  */
-package io.confluent.parallelconsumer.integrationTests;
 
 import io.confluent.csid.utils.ProgressBarUtils;
 import io.confluent.parallelconsumer.ParallelConsumerOptions;

--- a/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/TransactionAndCommitModeTest.java
+++ b/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/TransactionAndCommitModeTest.java
@@ -1,7 +1,7 @@
 package io.confluent.parallelconsumer.integrationTests;
 
 /*-
- * Copyright (C) 2020-2021 Confluent, Inc.
+ * Copyright (C) 2020-2022 Confluent, Inc.
  */
 
 import io.confluent.csid.utils.EnumCartesianProductTestSets;
@@ -226,7 +226,7 @@ class TransactionAndCommitModeTest extends BrokerIntegrationTest<String, String>
 //                            })
                     .alias(failureMessage)
                     .untilAsserted(() -> {
-                        log.info("Processed-count: {}, Produced-count: {}", processedCount.get(), producedCount.get());
+                        log.trace("Processed-count: {}, Produced-count: {}", processedCount.get(), producedCount.get());
                         int delta = producedCount.get() - processedCount.get();
                         if (delta == numThreads && pt.getRounds().get() > 1) {
                             log.error("Here we go fishy...");

--- a/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/utils/KafkaClientUtils.java
+++ b/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/utils/KafkaClientUtils.java
@@ -2,10 +2,6 @@
 /*-
  * Copyright (C) 2020-2022 Confluent, Inc.
  */
-
-/*-
- * Copyright (C) 2020 Confluent, Inc.
- */
 package io.confluent.parallelconsumer.integrationTests.utils;
 
 import lombok.Getter;

--- a/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/utils/KafkaClientUtils.java
+++ b/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/utils/KafkaClientUtils.java
@@ -26,6 +26,7 @@ import static java.time.Duration.ofSeconds;
 public class KafkaClientUtils {
 
     public static final int MAX_POLL_RECORDS = 10_000;
+    public static final String GROUP_ID_PREFIX = "group-1-";
 
     private final KafkaContainer kContainer;
 
@@ -37,6 +38,8 @@ public class KafkaClientUtils {
 
     @Getter
     private AdminClient admin;
+    private final String groupId = GROUP_ID_PREFIX + RandomUtils.nextInt();
+
 
     public KafkaClientUtils(KafkaContainer kafkaContainer) {
         kafkaContainer.addEnv("KAFKA_transaction_state_log_replication_factor", "1");
@@ -65,7 +68,7 @@ public class KafkaClientUtils {
         var consumerProps = setupCommonProps();
 
         //
-        consumerProps.put(ConsumerConfig.GROUP_ID_CONFIG, "group-1-" + RandomUtils.nextInt());
+        consumerProps.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
         consumerProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, OffsetResetStrategy.EARLIEST.name().toLowerCase());
         consumerProps.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
         consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
@@ -116,7 +119,7 @@ public class KafkaClientUtils {
         Properties properties = setupConsumerProps();
 
         if (newConsumerGroup) {
-            properties.put(ConsumerConfig.GROUP_ID_CONFIG, "group-1-" + RandomUtils.nextInt()); // new group
+            properties.put(ConsumerConfig.GROUP_ID_CONFIG, GROUP_ID_PREFIX + RandomUtils.nextInt()); // new group
         }
 
         // override with custom

--- a/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/utils/KafkaClientUtils.java
+++ b/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/utils/KafkaClientUtils.java
@@ -1,8 +1,7 @@
-
+package io.confluent.parallelconsumer.integrationTests.utils;
 /*-
  * Copyright (C) 2020-2022 Confluent, Inc.
  */
-package io.confluent.parallelconsumer.integrationTests.utils;
 
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;

--- a/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/utils/KafkaClientUtils.java
+++ b/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/utils/KafkaClientUtils.java
@@ -1,9 +1,14 @@
 
 /*-
+ * Copyright (C) 2020-2022 Confluent, Inc.
+ */
+
+/*-
  * Copyright (C) 2020 Confluent, Inc.
  */
 package io.confluent.parallelconsumer.integrationTests.utils;
 
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.RandomUtils;
 import org.apache.kafka.clients.admin.AdminClient;
@@ -26,48 +31,60 @@ import static java.time.Duration.ofSeconds;
 public class KafkaClientUtils {
 
     public static final int MAX_POLL_RECORDS = 10_000;
+
     private final KafkaContainer kContainer;
-    public Properties props = new Properties();
 
-    public KafkaConsumer<String, String> consumer;
+    @Getter
+    private KafkaConsumer<String, String> consumer;
 
-    public KafkaProducer<String, String> producer;
+    @Getter
+    private KafkaProducer<String, String> producer;
 
-    public AdminClient admin;
+    @Getter
+    private AdminClient admin;
 
     public KafkaClientUtils(KafkaContainer kafkaContainer) {
         kafkaContainer.addEnv("KAFKA_transaction_state_log_replication_factor", "1");
         kafkaContainer.addEnv("KAFKA_transaction_state_log_min_isr", "1");
         kafkaContainer.start();
         this.kContainer = kafkaContainer;
-        setupProps();
     }
 
-    public void setupProps() {
+    private Properties setupCommonProps() {
+        var commonProps = new Properties();
         String servers = this.kContainer.getBootstrapServers();
+        commonProps.put("bootstrap.servers", servers);
+        return commonProps;
+    }
 
-        props.put("bootstrap.servers", servers);
-        props.put(ConsumerConfig.GROUP_ID_CONFIG, "group-1-" + RandomUtils.nextInt());
-        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, OffsetResetStrategy.EARLIEST.name().toLowerCase());
+    private Properties setupProducerProps() {
+        var producerProps = setupCommonProps();
 
-        props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
+        producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+
+        return producerProps;
+    }
+
+    private Properties setupConsumerProps() {
+        var consumerProps = setupCommonProps();
 
         //
-        props.put("key.serializer", StringSerializer.class.getName());
-        props.put("value.serializer", StringSerializer.class.getName());
-        props.put("key.deserializer", StringDeserializer.class.getName());
-        props.put("value.deserializer", StringDeserializer.class.getName());
+        consumerProps.put(ConsumerConfig.GROUP_ID_CONFIG, "group-1-" + RandomUtils.nextInt());
+        consumerProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, OffsetResetStrategy.EARLIEST.name().toLowerCase());
+        consumerProps.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
+        consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
 
         //
-        props.put(ProducerConfig.TRANSACTION_TIMEOUT_CONFIG, (int) ofSeconds(10).toMillis()); // speed things up
-
-        //
-//    props.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, 10);
-//    props.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, 100);
+        //    consumerProps.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, 10);
+        //    consumerProps.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, 100);
 
         // make sure we can download lots of records if they're small. Default is 500
-//        props.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 1_000_000);
-        props.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, MAX_POLL_RECORDS);
+//        consumerProps.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 1_000_000);
+        consumerProps.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, MAX_POLL_RECORDS);
+
+        return consumerProps;
     }
 
     @BeforeEach
@@ -75,7 +92,7 @@ public class KafkaClientUtils {
         log.info("Setting up clients...");
         consumer = this.createNewConsumer();
         producer = this.createNewProducer(false);
-        admin = AdminClient.create(props);
+        admin = AdminClient.create(setupCommonProps());
     }
 
     @AfterEach
@@ -96,19 +113,31 @@ public class KafkaClientUtils {
         return createNewConsumer(newConsumerGroup, new Properties());
     }
 
+    public <K, V> KafkaConsumer<K, V> createNewConsumer(Properties options) {
+        return createNewConsumer(false, options);
+    }
+
     public <K, V> KafkaConsumer<K, V> createNewConsumer(boolean newConsumerGroup, Properties options) {
+        Properties properties = setupConsumerProps();
+
         if (newConsumerGroup) {
-            props.put(ConsumerConfig.GROUP_ID_CONFIG, "group-1-" + RandomUtils.nextInt()); // new group
+            properties.put(ConsumerConfig.GROUP_ID_CONFIG, "group-1-" + RandomUtils.nextInt()); // new group
         }
-        props.putAll(options);
-        KafkaConsumer<K, V> kvKafkaConsumer = new KafkaConsumer<>(props);
+
+        // override with custom
+        properties.putAll(options);
+
+        KafkaConsumer<K, V> kvKafkaConsumer = new KafkaConsumer<>(properties);
         log.debug("New consume {}", kvKafkaConsumer);
         return kvKafkaConsumer;
     }
 
     public <K, V> KafkaProducer<K, V> createNewProducer(boolean tx) {
+        Properties properties = setupProducerProps();
+
         var txProps = new Properties();
-        txProps.putAll(props);
+        txProps.putAll(properties);
+
         if (tx) {
             // random number so we get a unique producer tx session each time. Normally wouldn't do this in production,
             // but sometimes running in the test suite our producers step on each other between test runs and this causes
@@ -116,8 +145,11 @@ public class KafkaClientUtils {
             // Error looks like: Producer attempted an operation with an old epoch. Either there is a newer producer with
             // the same transactionalId, or the producer's transaction has been expired by the broker.
             txProps.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, this.getClass().getSimpleName() + ":" + RandomUtils.nextInt()); // required for tx
+            txProps.put(ProducerConfig.TRANSACTION_TIMEOUT_CONFIG, (int) ofSeconds(10).toMillis()); // speed things up
+
         }
         KafkaProducer<K, V> kvKafkaProducer = new KafkaProducer<>(txProps);
+
         log.debug("New producer {}", kvKafkaProducer);
         return kvKafkaProducer;
     }

--- a/parallel-consumer-examples/parallel-consumer-example-streams/src/test/java/io/confluent/parallelconsumer/examples/streams/StreamsAppTest.java
+++ b/parallel-consumer-examples/parallel-consumer-example-streams/src/test/java/io/confluent/parallelconsumer/examples/streams/StreamsAppTest.java
@@ -1,9 +1,8 @@
 package io.confluent.parallelconsumer.examples.streams;
 
 /*-
- * Copyright (C) 2020 Confluent, Inc.
+ * Copyright (C) 2020-2022 Confluent, Inc.
  */
-
 import io.confluent.parallelconsumer.integrationTests.BrokerIntegrationTest;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
@@ -47,7 +46,7 @@ public class StreamsAppTest extends BrokerIntegrationTest<String, String> {
 
         @Override
         Consumer<String, String> getKafkaConsumer() {
-            return kcu.consumer;
+            return kcu.getConsumer();
         }
 
         @Override

--- a/parallel-consumer-examples/parallel-consumer-example-streams/src/test/java/io/confluent/parallelconsumer/examples/streams/StreamsAppTest.java
+++ b/parallel-consumer-examples/parallel-consumer-example-streams/src/test/java/io/confluent/parallelconsumer/examples/streams/StreamsAppTest.java
@@ -3,6 +3,7 @@ package io.confluent.parallelconsumer.examples.streams;
 /*-
  * Copyright (C) 2020-2022 Confluent, Inc.
  */
+
 import io.confluent.parallelconsumer.integrationTests.BrokerIntegrationTest;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;

--- a/parallel-consumer-examples/parallel-consumer-example-streams/src/test/java/io/confluent/parallelconsumer/examples/streams/StreamsAppTest.java
+++ b/parallel-consumer-examples/parallel-consumer-example-streams/src/test/java/io/confluent/parallelconsumer/examples/streams/StreamsAppTest.java
@@ -1,5 +1,4 @@
 package io.confluent.parallelconsumer.examples.streams;
-
 /*-
  * Copyright (C) 2020-2022 Confluent, Inc.
  */

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
 
         <!-- version numbers -->
         <!-- plugins -->
-        <mycila.version>4.1</mycila.version>
+        <mycila.version>4.2.rc2</mycila.version>
         <lombok.version>1.18.16</lombok.version>
         <auto-service.version>1.0-rc7</auto-service.version>
         <surefire.version>3.0.0-M5</surefire.version>


### PR DESCRIPTION
Cleans up warnings in logs of ignored properties.