### PR TITLE
docs: Correctly render includes when editing README template

### DIFF
--- a/.idea/runConfigurations/asciidoc_template_build.xml
+++ b/.idea/runConfigurations/asciidoc_template_build.xml
@@ -11,6 +11,7 @@
           <option name="goals">
             <list>
               <option value="asciidoc-template:build" />
+              <option value="-e" />
             </list>
           </option>
           <option name="pomFileName" value="pom.xml" />

--- a/README.adoc
+++ b/README.adoc
@@ -10,6 +10,18 @@
 //
 
 
+// dynamic include base for editing in IDEA
+:project_root: ./
+// for editing the template to see the includes, this will correctly render includes
+ifeval::["{docname}" == "README_TEMPLATE"]
+
+TIP:: Editing template file
+
+:project_root: ../../
+
+endif::[]
+
+
 = Confluent Parallel Consumer
 :icons:
 :toc: macro
@@ -21,14 +33,6 @@
 :github_name: parallel-consumer
 :base_url: https://github.com/confluentinc/{github_name}
 :issues_link: {base_url}/issues
-
-// dynamic include base for editing in IDEA
-:project_root: ./
-
-// uncomment the following if not using IDEA or having issues, for editing the template to see the includes
-// note that with this line not commented out, the rendering of the root level asiidoc file will be incorrect (i.e.
-// leave it commented out when committing work)
-//:project_root: ../../
 
 
 ifdef::env-github[]

--- a/README.adoc
+++ b/README.adoc
@@ -1,7 +1,7 @@
 //
-// STOP!!! Make sure you're editing the TEMPLATE version of the README, in /src/docs/README.adoc
+// STOP!!! Make sure you're editing the TEMPLATE version of the README, in /src/docs/README_TEMPLATE.adoc
 //
-// Do NOT edit /README.adoc as your changes will be overwritten when the template is rendered again during
+// Do NOT edit /README_TEMPLATE.adoc as your changes will be overwritten when the template is rendered again during
 // `process-sources`.
 //
 // Changes made to this template, must then be rendered to the base readme, by running `mvn process-sources`
@@ -955,7 +955,7 @@ ParallelEoSStreamProcessorTestBase#DEFAULT_COMMIT_INTERVAL_MAX_MS
 The `README` uses a special https://github.com/whelk-io/asciidoc-template-maven-plugin/pull/25[custom maven processor plugin] to import live code blocks into the root readme, so that GitHub can show the real code as includes in the `README`.
 This is because GitHub https://github.com/github/markup/issues/1095[doesn't properly support the _include_ directive].
 
-The source of truth readme is in link:{project_root}/src/docs/README.adoc[].
+The source of truth readme is in link:{project_root}/src/docs/README_TEMPLATE.adoc[].
 
 === Maven targets
 

--- a/pom.xml
+++ b/pom.xml
@@ -522,7 +522,7 @@
                 </executions>
                 <configuration>
                     <templateDirectory>./</templateDirectory>
-                    <templateFile>src/docs/README.adoc</templateFile>
+                    <templateFile>src/docs/README_TEMPLATE.adoc</templateFile>
                     <outputDirectory>./</outputDirectory>
                     <outputFile>README.adoc</outputFile>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -510,7 +510,7 @@
             <plugin>
                 <groupId>io.whelk.asciidoc</groupId>
                 <artifactId>asciidoc-template-maven-plugin</artifactId>
-                <version>1.0.18</version>
+                <version>1.0.20</version>
                 <executions>
                     <execution>
                         <id>process</id>
@@ -521,8 +521,8 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <templateDirectory>./</templateDirectory>
-                    <templateFile>src/docs/README_TEMPLATE.adoc</templateFile>
+                    <templateDirectory>src/docs/</templateDirectory>
+                    <templateFile>README_TEMPLATE.adoc</templateFile>
                     <outputDirectory>./</outputDirectory>
                     <outputFile>README.adoc</outputFile>
                 </configuration>

--- a/src/docs/README_TEMPLATE.adoc
+++ b/src/docs/README_TEMPLATE.adoc
@@ -1,13 +1,25 @@
 //
-// STOP!!! Make sure you're editing the TEMPLATE version of the README, in /src/docs/README.adoc
+// STOP!!! Make sure you're editing the TEMPLATE version of the README, in /src/docs/README_TEMPLATE.adoc
 //
-// Do NOT edit /README.adoc as your changes will be overwritten when the template is rendered again during
+// Do NOT edit /README_TEMPLATE.adoc as your changes will be overwritten when the template is rendered again during
 // `process-sources`.
 //
 // Changes made to this template, must then be rendered to the base readme, by running `mvn process-sources`
 //
 // To render the README directly, run `mvn asciidoc-template::build`
 //
+
+
+// dynamic include base for editing in IDEA
+:project_root: ./
+// for editing the template to see the includes, this will correctly render includes
+ifeval::["{docname}" == "README_TEMPLATE"]
+
+TIP:: Editing template file
+
+:project_root: ../../
+
+endif::[]
 
 
 = Confluent Parallel Consumer
@@ -22,12 +34,7 @@
 :base_url: https://github.com/confluentinc/{github_name}
 :issues_link: {base_url}/issues
 
-// dynamic include base for editing in IDEA
-:project_root: ./
 
-// uncomment the following if not using IDEA or having issues, for editing the template to see the includes
-// note that with this line not commented out, the rendering of the root level asiidoc file will be incorrect (i.e.
-// leave it commented out when committing work)
 //:project_root: ../../
 
 

--- a/src/docs/README_TEMPLATE.adoc
+++ b/src/docs/README_TEMPLATE.adoc
@@ -35,9 +35,6 @@ endif::[]
 :issues_link: {base_url}/issues
 
 
-//:project_root: ../../
-
-
 ifdef::env-github[]
 :tip-caption: :bulb:
 :note-caption: :information_source:
@@ -818,7 +815,7 @@ ParallelEoSStreamProcessorTestBase#DEFAULT_COMMIT_INTERVAL_MAX_MS
 The `README` uses a special https://github.com/whelk-io/asciidoc-template-maven-plugin/pull/25[custom maven processor plugin] to import live code blocks into the root readme, so that GitHub can show the real code as includes in the `README`.
 This is because GitHub https://github.com/github/markup/issues/1095[doesn't properly support the _include_ directive].
 
-The source of truth readme is in link:{project_root}/src/docs/README.adoc[].
+The source of truth readme is in link:{project_root}/src/docs/README_TEMPLATE.adoc[].
 
 === Maven targets
 


### PR DESCRIPTION
Blocked by: 
- https://github.com/whelk-io/asciidoc-template-maven-plugin/pull/119