### PR TITLE
build: OSS Index scan change to warn only and exclude Guava CVE-2020-8908 as it's WONT_FIX

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -70,7 +70,7 @@ It also opens up new use cases like extreme parallelism, external data enrichmen
 .Consume many messages _concurrently_ with a *single* consumer instance:
 [source,java,indent=0]
 ----
-                        parallelConsumer.poll(record ->
+        parallelConsumer.poll(record ->
                 log.info("Concurrently processing a record: {}", record)
         );
 ----
@@ -438,7 +438,7 @@ Where `${project.version}` is the version to be used:
                 .producer(kafkaProducer)
                 .build();
 
-        ParallelEoSStreamProcessor<String, String> eosStreamProcessor =
+        ParallelStreamProcessor<String, String> eosStreamProcessor =
                 ParallelStreamProcessor.createEosStreamProcessor(options);
 
         eosStreamProcessor.subscribe(of(inputTopic)); // <4>
@@ -489,7 +489,7 @@ This is the only thing you need to do, in order to get massively concurrent proc
 
 .Usage - print message content out to the console in parallel
 [source,java,indent=0]
-                        parallelConsumer.poll(record ->
+        parallelConsumer.poll(record ->
                 log.info("Concurrently processing a record: {}", record)
         );
 

--- a/README.adoc
+++ b/README.adoc
@@ -70,7 +70,7 @@ It also opens up new use cases like extreme parallelism, external data enrichmen
 .Consume many messages _concurrently_ with a *single* consumer instance:
 [source,java,indent=0]
 ----
-        parallelConsumer.poll(record ->
+                        parallelConsumer.poll(record ->
                 log.info("Concurrently processing a record: {}", record)
         );
 ----
@@ -438,7 +438,7 @@ Where `${project.version}` is the version to be used:
                 .producer(kafkaProducer)
                 .build();
 
-        ParallelStreamProcessor<String, String> eosStreamProcessor =
+        ParallelEoSStreamProcessor<String, String> eosStreamProcessor =
                 ParallelStreamProcessor.createEosStreamProcessor(options);
 
         eosStreamProcessor.subscribe(of(inputTopic)); // <4>
@@ -489,7 +489,7 @@ This is the only thing you need to do, in order to get massively concurrent proc
 
 .Usage - print message content out to the console in parallel
 [source,java,indent=0]
-        parallelConsumer.poll(record ->
+                        parallelConsumer.poll(record ->
                 log.info("Concurrently processing a record: {}", record)
         );
 

--- a/pom.xml
+++ b/pom.xml
@@ -189,35 +189,6 @@
                 <license.mode>check</license.mode>
                 <parallel-tests>false</parallel-tests>
             </properties>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-enforcer-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>enforce-versions</id>
-                                <goals>
-                                    <goal>enforce</goal>
-                                </goals>
-                                <phase>validate</phase>
-                                <configuration>
-                                    <rules>
-                                        <!-- only enforce requireReleaseDeps when running in CI, not locally -->
-                                        <requireReleaseDeps>
-                                            <onlyWhenRelease>false</onlyWhenRelease>
-                                            <failWhenParentIsSnapshot>false</failWhenParentIsSnapshot>
-                                            <excludes>
-                                                <exclude>io.confluent.parallelconsumer:</exclude>
-                                            </excludes>
-                                        </requireReleaseDeps>
-                                    </rules>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
         </profile>
         <profile>
             <id>maven-central</id>
@@ -763,6 +734,13 @@
                                 <reactorModuleConvergence />
                                 <banDuplicatePomDependencyVersions />
                                 <requireSameVersions />
+                                <requireReleaseDeps>
+                                    <onlyWhenRelease>false</onlyWhenRelease>
+                                    <failWhenParentIsSnapshot>false</failWhenParentIsSnapshot>
+                                    <excludes>
+                                        <exclude>io.confluent.parallelconsumer:</exclude>
+                                    </excludes>
+                                </requireReleaseDeps>
                             </rules>
                         </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -492,6 +492,8 @@
                 <artifactId>ossindex-maven-plugin</artifactId>
                 <version>3.2.0</version>
                 <configuration>
+                    <scope>runtime</scope>
+                    <fail>false</fail>
                     <excludeCoordinates>
                         <exclude>
                             <!-- https://github.com/google/guava/issues/4011 -->
@@ -512,10 +514,6 @@
                         </goals>
                     </execution>
                 </executions>
-                <configuration>
-                    <scope>runtime</scope>
-                    <fail>false</fail>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>com.soebes.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -189,6 +189,35 @@
                 <license.mode>check</license.mode>
                 <parallel-tests>false</parallel-tests>
             </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-enforcer-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>enforce-versions</id>
+                                <goals>
+                                    <goal>enforce</goal>
+                                </goals>
+                                <phase>validate</phase>
+                                <configuration>
+                                    <rules>
+                                        <!-- only enforce requireReleaseDeps when running in CI, not locally -->
+                                        <requireReleaseDeps>
+                                            <onlyWhenRelease>false</onlyWhenRelease>
+                                            <failWhenParentIsSnapshot>false</failWhenParentIsSnapshot>
+                                            <excludes>
+                                                <exclude>io.confluent.parallelconsumer:</exclude>
+                                            </excludes>
+                                        </requireReleaseDeps>
+                                    </rules>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
         <profile>
             <id>maven-central</id>
@@ -734,13 +763,6 @@
                                 <reactorModuleConvergence />
                                 <banDuplicatePomDependencyVersions />
                                 <requireSameVersions />
-                                <requireReleaseDeps>
-                                    <onlyWhenRelease>false</onlyWhenRelease>
-                                    <failWhenParentIsSnapshot>false</failWhenParentIsSnapshot>
-                                    <excludes>
-                                        <exclude>io.confluent.parallelconsumer:</exclude>
-                                    </excludes>
-                                </requireReleaseDeps>
                             </rules>
                         </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -514,6 +514,7 @@
                 </executions>
                 <configuration>
                     <scope>runtime</scope>
+                    <fail>false</fail>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -491,6 +491,18 @@
                 <groupId>org.sonatype.ossindex.maven</groupId>
                 <artifactId>ossindex-maven-plugin</artifactId>
                 <version>3.2.0</version>
+                <configuration>
+                    <excludeCoordinates>
+                        <exclude>
+                            <!-- https://github.com/google/guava/issues/4011 -->
+                            <!-- CVE-2020-8908: Files::createTempDir local information disclosure vulnerability #4011 -->
+                            <!-- only used transitively from tests, and is a deprecated function -->
+                            <groupId>com.google.guava</groupId>
+                            <artifactId>guava</artifactId>
+                            <version>31.1-jre</version>
+                        </exclude>
+                    </excludeCoordinates>
+                </configuration>
                 <executions>
                     <execution>
                         <id>audit-dependencies</id>

--- a/pom.xml
+++ b/pom.xml
@@ -512,6 +512,9 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <scope>runtime</scope>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>com.soebes.maven.plugins</groupId>


### PR DESCRIPTION
- CVE-2020-8908: Files::createTempDir local information disclosure vulnerability #4011
- Only used transitively from tests, and is a deprecated function
- https://github.com/google/guava/issues/4011

Description...

### Checklist

- [ ] Documentation (if applicable)
- [ ] Changelog