### PR TITLE
fixes #375: Mockito dependency should be test scoped

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -336,6 +336,7 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
             <version>${mockito.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.google.auto.service</groupId>


### PR DESCRIPTION
From parent pom.xml, mockito dependency is not scoped as test.
https://github.com/confluentinc/parallel-consumer/issues/375
