### PR TITLE
fixes #419 NoSuchElementException during race condition in PartitionState

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -23,6 +23,9 @@ endif::[]
 ** Fixes a potential race condition which could cause offset leaks between transactions boundaries.
 ** Introduces lock acquisition timeouts.
 ** Fixes a potential issue with removing records from the retry queue incorrectly, by having an inconsistency between compareTo and equals in the retry TreeMap.
+
+=== Fixes
+
 * fixes #419 NoSuchElementException during race condition in PartitionState (#422)
 
 == v0.5.2.3

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -23,6 +23,7 @@ endif::[]
 ** Fixes a potential race condition which could cause offset leaks between transactions boundaries.
 ** Introduces lock acquisition timeouts.
 ** Fixes a potential issue with removing records from the retry queue incorrectly, by having an inconsistency between compareTo and equals in the retry TreeMap.
+* fixes #419 NoSuchElementException during race condition in PartitionState (#422)
 
 == v0.5.2.3
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -23,17 +23,22 @@ endif::[]
 ** Fixes a potential race condition which could cause offset leaks between transactions boundaries.
 ** Introduces lock acquisition timeouts.
 ** Fixes a potential issue with removing records from the retry queue incorrectly, by having an inconsistency between compareTo and equals in the retry TreeMap.
+* Adds a very simple Dependency Injection system modeled on Dagger (#398)
+* Various refactorings e.g. new ProducerWrap
+
+* Dependencies
+** build(deps): prod: zstd, reactor, dev: podam, progressbar, postgresql maven-plugins: versions, help (#420)
+** build(deps-dev): bump postgresql from 42.4.1 to 42.5.0
+** bump podam, progressbar, zstd, reactor
+** build(deps): bump versions-maven-plugin from 2.11.0 to 2.12.0
+** build(deps): bump maven-help-plugin from 3.2.0 to 3.3.0
+** build(deps-dev): bump Confluent Platform Kafka Broker to 7.2.2 (#421)
+** build(deps): Upgrade to AK 3.3.0 (#309)
 
 === Fixes
 
 * fixes #419 NoSuchElementException during race condition in PartitionState (#422)
 
-== v0.5.2.3
-
-=== Improvements
-
-- Adds a very simple Dependency Injection system modeled on Dagger (#398)
-- Various refactorings e.g. new ProducerWrap
 
 == v0.5.2.2
 

--- a/README.adoc
+++ b/README.adoc
@@ -1279,6 +1279,7 @@ endif::[]
 ** Fixes a potential race condition which could cause offset leaks between transactions boundaries.
 ** Introduces lock acquisition timeouts.
 ** Fixes a potential issue with removing records from the retry queue incorrectly, by having an inconsistency between compareTo and equals in the retry TreeMap.
+* fixes #419 NoSuchElementException during race condition in PartitionState (#422)
 
 == v0.5.2.3
 


### PR DESCRIPTION
In busy situations, there is a race condition in PartitionState due to it being edited by the Controller, and read by the BrokerPoller.

Because the check and subsequent read of the incompleteOffsets collection are two different operations, it can initially appear as though it has elements, but when we try to retrieve an element, it can then be empty, which throws a NoSuchElementException.

Thanks to a very elegant fix suggested by @shaileshkulkarni, we can combine the check and retrieval by using the thread safe #ceiling method, which can either returns the #first element, or null if empty.

This is as opposed to the more brute force solution which would require using locks.

This, among other things, will be made redundant once #200 (a shared nothing architecture) is merged.

Description...

### Checklist

- [x] Changelog