### PR TITLE
build(deps-dev): Fix Slf4j setup caused by shaded Wiremock dep (slf4j/logback collisions)

### DIFF
--- a/parallel-consumer-core/pom.xml
+++ b/parallel-consumer-core/pom.xml
@@ -90,7 +90,7 @@
         </dependency>
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock</artifactId>
+            <artifactId>wiremock-jre8</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/parallel-consumer-examples/parallel-consumer-example-reactor/pom.xml
+++ b/parallel-consumer-examples/parallel-consumer-example-reactor/pom.xml
@@ -49,7 +49,7 @@
         </dependency>
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock</artifactId>
+            <artifactId>wiremock-jre8</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/parallel-consumer-examples/parallel-consumer-example-vertx/pom.xml
+++ b/parallel-consumer-examples/parallel-consumer-example-vertx/pom.xml
@@ -49,7 +49,7 @@
         </dependency>
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock</artifactId>
+            <artifactId>wiremock-jre8</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/parallel-consumer-vertx/pom.xml
+++ b/parallel-consumer-vertx/pom.xml
@@ -49,7 +49,7 @@
         </dependency>
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock</artifactId>
+            <artifactId>wiremock-jre8</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -488,8 +488,8 @@
             </dependency>
             <dependency>
                 <groupId>com.github.tomakehurst</groupId>
-                <artifactId>wiremock</artifactId>
-                <version>2.33.2</version>
+                <artifactId>wiremock-jre8</artifactId>
+                <version>2.34.0</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>


### PR DESCRIPTION
- Fix Slf4j setup by switching away from and bumping Wiremock fat dependency (slf4j/logback collisions)
- Upgrades Wiremock from 2.33.2 to 2.34.0

### Checklist

- [ ] Changelog