### PR TITLE
Update service.yml - disable semaphore

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -9,4 +9,4 @@ github:
     enable: true
     repo_name: confluentinc/parallel-consumer
 semaphore:
-    enable: true
+    enable: false


### PR DESCRIPTION
Disabling semaphore for cc-service-bot since the repo does not use semaphore (and shouldn't since it is public).