### PR TITLE
DP-9370 - use cc-service-bot to manage Semaphore project

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -9,4 +9,7 @@ github:
     enable: true
     repo_name: confluentinc/parallel-consumer
 semaphore:
-    enable: false
+  enable: true
+  pipeline_enable: false
+  triggers: []
+  branches: []


### PR DESCRIPTION
This PR onboards the repo to cc-service-bot for managing its Semaphore project via code.