### PR TITLE
docs: Remove legacy config maxUncommittedMessagesToHandle from readme

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -305,7 +305,6 @@ As an illustrative example of relative performance, given:
 * 10,000 messages to process
 * A single partition (simplifies comparison - a topic with 5 partitions is the same as 1 partition with a keyspace of 5)
 * Default `ParallelConsumerOptions`
-** maxUncommittedMessagesToHandle = 1000
 ** maxConcurrency = 100
 ** numberOfThreads = 16
 

--- a/src/docs/README_TEMPLATE.adoc
+++ b/src/docs/README_TEMPLATE.adoc
@@ -303,7 +303,6 @@ As an illustrative example of relative performance, given:
 * 10,000 messages to process
 * A single partition (simplifies comparison - a topic with 5 partitions is the same as 1 partition with a keyspace of 5)
 * Default `ParallelConsumerOptions`
-** maxUncommittedMessagesToHandle = 1000
 ** maxConcurrency = 100
 ** numberOfThreads = 16
 


### PR DESCRIPTION
The configuration was removed a long time ago, when we added per record ack persistence, didn't think it was needed as it's original intent was to prevent big replay upon rebalance (as per record ack wasn't persisted).

See https://github.com/confluentinc/parallel-consumer/issues/490

Description...

### Checklist

- [ ] Documentation (if applicable)
- [ ] Changelog