### PR TITLE
fix: After new performance fix PR#530 merges - corner case could cause out of order processing

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -19,6 +19,11 @@ endif::[]
 === Fixes
 
 * fixes: #195 NoSuchFieldException when using consumer inherited from KafkaConsumer (#469)
+* fix: After new performance fix PR#530 merges - corner case could cause out of order processing (#534)
+
+=== Improvements
+
+* perf: Adds a caching layer to work management to alleviate O(n) counting (#530)
 
 == 0.5.2.4
 

--- a/README.adoc
+++ b/README.adoc
@@ -1317,6 +1317,11 @@ endif::[]
 === Fixes
 
 * fixes: #195 NoSuchFieldException when using consumer inherited from KafkaConsumer (#469)
+* fix: After new performance fix PR#530 merges - corner case could cause out of order processing (#534)
+
+=== Improvements
+
+* perf: Adds a caching layer to work management to alleviate O(n) counting (#530)
 
 == 0.5.2.4
 

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/state/ProcessingShard.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/state/ProcessingShard.java
@@ -107,12 +107,12 @@ public class ProcessingShard<K, V> {
             var workContainer = iterator.next().getValue();
 
             if (pm.couldBeTakenAsWork(workContainer)) {
-
                 if (workContainer.isAvailableToTakeAsWork()) {
                     log.trace("Taking {} as work", workContainer);
                     workContainer.onQueueingForExecution();
                     workTaken.add(workContainer);
                 } else {
+                    log.trace("Skipping {} as work, not available to take as work", workContainer);
                     addToSlowWorkMaybe(slowWork, workContainer);
                 }
 
@@ -122,6 +122,15 @@ public class ProcessingShard<K, V> {
                     log.trace("Processing by {}, so have cannot get more messages on this ({}) shardEntry.", this.options.getOrdering(), getKey());
                     break;
                 }
+            } else {
+                // break, assuming all work in this shard, is for the same ShardKey, which is always on the same
+                //  partition (regardless of ordering mode - KEY, PARTITION or UNORDERED (which is parallel PARTITIONs)),
+                //  so no point continuing shard scanning. This only isn't true if a non standard partitioner produced the
+                //  recrods of the same key to different partitions. In which case, there's no way PC can make sure all
+                //  records of that belong to the shard are able to even be processed by the same PC instance, so it doesn't
+                //  matter.
+                log.trace("Partition for shard {} is blocked for work taking, stopping shard scan", this);
+                break;
             }
         }
 

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/state/WorkContainer.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/state/WorkContainer.java
@@ -201,7 +201,7 @@ public class WorkContainer<K, V> implements Comparable<WorkContainer<K, V>> {
 
     @Override
     public String toString() {
-        return "WorkContainer(" + toTopicPartition(cr) + ":" + cr.offset() + ":" + cr.key() + ")";
+        return "WorkContainer(tp:" + toTopicPartition(cr) + ":o:" + cr.offset() + ":k:" + cr.key() + ")";
     }
 
     public Duration getTimeInFlight() {


### PR DESCRIPTION
> Under unrealistically high load with no-op processing, broker poller unblocking a partition could cause ProcessingShard to skip forward in its entries and take work out of order.
> Was discovered when fixing a synthetic high performance benchmark, after an O(n) algo was fixed to O(1), creating the state for the race condition to appear. Probably could not happen without the fix, as it's related to the performance of certain parts of the system.
> This sort of issue won't be possible once the new IPC system is merged and Thread contracts established. 

Related:
- #530 
- #325 
- #270 

### Checklist

- [x] Changelog