### PR TITLE
improves: Error in onPartitionsAssigned in parallel consumer

### DIFF
--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/ParallelConsumerOptions.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/ParallelConsumerOptions.java
@@ -301,7 +301,27 @@ public class ParallelConsumerOptions<K, V> {
 
     public static final Duration DEFAULT_STATIC_RETRY_DELAY = Duration.ofSeconds(1);
 
-    public enum InvalidOffsetMetadataHandlingPolicy { FAIL, IGNORE }
+    /**
+     * Error handling strategy to use when invalid offsets metadata is encountered. This could happen accidentally or
+     * deliberately if the user attempts to reuse an existing consumer group id.
+     */
+    public enum InvalidOffsetMetadataHandlingPolicy {
+        /**
+         * Fails and shuts down the application. This is the default.
+         */
+        FAIL,
+        /**
+         * Ignore the error, logs a warning message and continue processing from the last committed offset.
+         */
+        IGNORE
+    }
+
+    /**
+     * Controls the error handling behaviour to use when invalid offsets metadata from a pre-existing consumer group is encountered.
+     * A potential scenario where this could occur is when a consumer group id from a Kafka Streams application is accidentally reused.
+     * <p>
+     * Default is {@link InvalidOffsetMetadataHandlingPolicy#FAIL}
+     */
     @Builder.Default
     private final InvalidOffsetMetadataHandlingPolicy invalidOffsetMetadataPolicy = InvalidOffsetMetadataHandlingPolicy.FAIL;
     /**

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/ParallelConsumerOptions.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/ParallelConsumerOptions.java
@@ -301,6 +301,9 @@ public class ParallelConsumerOptions<K, V> {
 
     public static final Duration DEFAULT_STATIC_RETRY_DELAY = Duration.ofSeconds(1);
 
+    public enum InvalidOffsetMetadataHandlingPolicy { FAIL, IGNORE }
+    @Builder.Default
+    private final InvalidOffsetMetadataHandlingPolicy invalidOffsetMetadataPolicy = InvalidOffsetMetadataHandlingPolicy.FAIL;
     /**
      * When a message fails, how long the system should wait before trying that message again. Note that this will not
      * be exact, and is just a target.

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/ParallelConsumerOptions.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/ParallelConsumerOptions.java
@@ -1,7 +1,7 @@
 package io.confluent.parallelconsumer;
 
 /*-
- * Copyright (C) 2020-2022 Confluent, Inc.
+ * Copyright (C) 2020-2023 Confluent, Inc.
  */
 
 import io.confluent.parallelconsumer.internal.AbstractParallelEoSStreamProcessor;

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/offsets/EncodedOffsetPair.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/offsets/EncodedOffsetPair.java
@@ -4,6 +4,7 @@ package io.confluent.parallelconsumer.offsets;
  * Copyright (C) 2020-2022 Confluent, Inc.
  */
 
+import io.confluent.parallelconsumer.ParallelConsumerOptions;
 import io.confluent.parallelconsumer.internal.InternalRuntimeException;
 import io.confluent.parallelconsumer.offsets.OffsetMapCodecManager.HighestOffsetAndIncompletes;
 import lombok.Getter;
@@ -101,8 +102,12 @@ public final class EncodedOffsetPair implements Comparable<EncodedOffsetPair> {
         return binaryArrayString;
     }
 
-    @SneakyThrows
     public HighestOffsetAndIncompletes getDecodedIncompletes(long baseOffset) {
+        return getDecodedIncompletes(baseOffset,  ParallelConsumerOptions.InvalidOffsetMetadataHandlingPolicy.FAIL);
+    }
+
+    @SneakyThrows
+    public HighestOffsetAndIncompletes getDecodedIncompletes(long baseOffset, ParallelConsumerOptions.InvalidOffsetMetadataHandlingPolicy errorPolicy) {
         HighestOffsetAndIncompletes binaryArrayString = switch (encoding) {
 //            case ByteArray -> deserialiseByteArrayToBitMapString(data);
 //            case ByteArrayCompressed -> deserialiseByteArrayToBitMapString(decompressZstd(data));
@@ -114,8 +119,14 @@ public final class EncodedOffsetPair implements Comparable<EncodedOffsetPair> {
             case BitSetV2Compressed -> deserialiseBitSetWrapToIncompletes(BitSetV2, baseOffset, decompressZstd(data));
             case RunLengthV2 -> runLengthDecodeToIncompletes(encoding, baseOffset, data);
             case RunLengthV2Compressed -> runLengthDecodeToIncompletes(RunLengthV2, baseOffset, decompressZstd(data));
-            case KafkaStreams, KafkaStreamsV2 ->
+            case KafkaStreams, KafkaStreamsV2 ->{
+                if (errorPolicy == ParallelConsumerOptions.InvalidOffsetMetadataHandlingPolicy.IGNORE) {
+                    log.warn("Ignoring existing Kafka Streams offset metadata and reusing offsets");
+                    yield HighestOffsetAndIncompletes.of(baseOffset);
+                } else {
                     throw new KafkaStreamsEncodingNotSupported();
+                }
+            }
             default ->
                     throw new UnsupportedOperationException("Encoding (" + encoding.description() + ") not supported");
         };

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/offsets/EncodedOffsetPair.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/offsets/EncodedOffsetPair.java
@@ -1,7 +1,7 @@
 package io.confluent.parallelconsumer.offsets;
 
 /*-
- * Copyright (C) 2020-2022 Confluent, Inc.
+ * Copyright (C) 2020-2023 Confluent, Inc.
  */
 
 import io.confluent.parallelconsumer.ParallelConsumerOptions;

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/offsets/OffsetMapCodecManager.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/offsets/OffsetMapCodecManager.java
@@ -103,7 +103,9 @@ public class OffsetMapCodecManager<K, V> {
     // todo remove consumer #233
     public OffsetMapCodecManager(PCModule<K, V> module) {
         this.module = module;
-        this.errorPolicy = module.options().getInvalidOffsetMetadataPolicy();
+        if (module != null){
+            this.errorPolicy = module.options().getInvalidOffsetMetadataPolicy();
+        }
     }
 
     /**

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/offsets/OffsetMapCodecManager.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/offsets/OffsetMapCodecManager.java
@@ -1,7 +1,7 @@
 package io.confluent.parallelconsumer.offsets;
 
 /*-
- * Copyright (C) 2020-2022 Confluent, Inc.
+ * Copyright (C) 2020-2023 Confluent, Inc.
  */
 
 import io.confluent.parallelconsumer.ParallelConsumerOptions;

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/offsets/OffsetMapCodecManager.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/offsets/OffsetMapCodecManager.java
@@ -4,6 +4,7 @@ package io.confluent.parallelconsumer.offsets;
  * Copyright (C) 2020-2022 Confluent, Inc.
  */
 
+import io.confluent.parallelconsumer.ParallelConsumerOptions;
 import io.confluent.parallelconsumer.internal.InternalRuntimeException;
 import io.confluent.parallelconsumer.internal.PCModule;
 import io.confluent.parallelconsumer.state.PartitionState;
@@ -62,6 +63,8 @@ public class OffsetMapCodecManager<K, V> {
 
     private final PCModule module;
 
+    private static ParallelConsumerOptions.InvalidOffsetMetadataHandlingPolicy errorPolicy = ParallelConsumerOptions.InvalidOffsetMetadataHandlingPolicy.FAIL;
+
     /**
      * Decoding result for encoded offsets
      */
@@ -100,6 +103,7 @@ public class OffsetMapCodecManager<K, V> {
     // todo remove consumer #233
     public OffsetMapCodecManager(PCModule<K, V> module) {
         this.module = module;
+        this.errorPolicy = module.options().getInvalidOffsetMetadataPolicy();
     }
 
     /**
@@ -243,7 +247,7 @@ public class OffsetMapCodecManager<K, V> {
             return HighestOffsetAndIncompletes.of(highestSeenOffsetIsThen);
         } else {
             var result = EncodedOffsetPair.unwrap(decodedBytes);
-            return result.getDecodedIncompletes(nextExpectedOffset);
+            return result.getDecodedIncompletes(nextExpectedOffset, errorPolicy);
         }
     }
 

--- a/parallel-consumer-core/src/test/java/io/confluent/parallelconsumer/offsets/WorkManagerOffsetMapCodecManagerTest.java
+++ b/parallel-consumer-core/src/test/java/io/confluent/parallelconsumer/offsets/WorkManagerOffsetMapCodecManagerTest.java
@@ -1,7 +1,7 @@
 package io.confluent.parallelconsumer.offsets;
 
 /*-
- * Copyright (C) 2020-2022 Confluent, Inc.
+ * Copyright (C) 2020-2023 Confluent, Inc.
  */
 
 import com.google.common.truth.Truth;


### PR DESCRIPTION
Improves: https://github.com/confluentinc/parallel-consumer/issues/326 

Adds an option to pass an invalid offset metadata error policy in case of accidentally or deliberately reusing a Kafka Streams consumer group. The default policy is to fail and stop the execution. 

### Checklist

- [ ] Documentation (if applicable)
- [ ] Changelog