### PR TITLE
Do not create trace log message when trace logging is not enabled

### DIFF
--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/internal/AbstractParallelEoSStreamProcessor.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/internal/AbstractParallelEoSStreamProcessor.java
@@ -860,10 +860,12 @@ public abstract class AbstractParallelEoSStreamProcessor<K, V> implements Parall
             listOfBatches.add(batchInConstruction);
         }
 
-        log.debug("sourceCollection.size() {}, batches: {}, batch sizes {}",
-                sourceCollection.size(),
-                listOfBatches.size(),
-                listOfBatches.stream().map(List::size).collect(Collectors.toList()));
+        if (log.isDebugEnabled()) {
+            log.debug("sourceCollection.size() {}, batches: {}, batch sizes {}",
+                    sourceCollection.size(),
+                    listOfBatches.size(),
+                    listOfBatches.stream().map(List::size).collect(Collectors.toList()));
+        }
         return listOfBatches;
     }
 

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/internal/AbstractParallelEoSStreamProcessor.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/internal/AbstractParallelEoSStreamProcessor.java
@@ -719,8 +719,10 @@ public abstract class AbstractParallelEoSStreamProcessor<K, V> implements Parall
         }
 
         // end of loop
-        log.trace("End of control loop, waiting processing {}, remaining in partition queues: {}, out for processing: {}. In state: {}",
-                wm.getNumberOfWorkQueuedInShardsAwaitingSelection(), wm.getNumberOfIncompleteOffsets(), wm.getNumberRecordsOutForProcessing(), state);
+        if (log.isTraceEnabled()) {
+            log.trace("End of control loop, waiting processing {}, remaining in partition queues: {}, out for processing: {}. In state: {}",
+                    wm.getNumberOfWorkQueuedInShardsAwaitingSelection(), wm.getNumberOfIncompleteOffsets(), wm.getNumberRecordsOutForProcessing(), state);
+        }
     }
 
     /**
@@ -1083,16 +1085,18 @@ public abstract class AbstractParallelEoSStreamProcessor<K, V> implements Parall
      * @return true if waiting to commit would help performance
      */
     private boolean lingeringOnCommitWouldBeBeneficial() {
-        // work is waiting to be done
-        boolean workIsWaitingToBeCompletedSuccessfully = wm.workIsWaitingToBeProcessed();
-        // no work is currently being done
-        boolean workInFlight = wm.hasWorkInFlight();
-        // work mailbox is empty
-        boolean workWaitingInMailbox = !workMailBox.isEmpty();
-        boolean workWaitingToProcess = wm.hasIncompleteOffsets();
-        log.trace("workIsWaitingToBeCompletedSuccessfully {} || workInFlight {} || workWaitingInMailbox {} || !workWaitingToProcess {};",
-                workIsWaitingToBeCompletedSuccessfully, workInFlight, workWaitingInMailbox, !workWaitingToProcess);
-        boolean result = workIsWaitingToBeCompletedSuccessfully || workInFlight || workWaitingInMailbox || !workWaitingToProcess;
+        if (log.isTraceEnabled()) {
+            // work is waiting to be done
+            boolean workIsWaitingToBeCompletedSuccessfully = wm.workIsWaitingToBeProcessed();
+            // no work is currently being done
+            boolean workInFlight = wm.hasWorkInFlight();
+            // work mailbox is empty
+            boolean workWaitingInMailbox = !workMailBox.isEmpty();
+            boolean workWaitingToProcess = wm.hasIncompleteOffsets();
+            log.trace("workIsWaitingToBeCompletedSuccessfully {} || workInFlight {} || workWaitingInMailbox {} || !workWaitingToProcess {};",
+                    workIsWaitingToBeCompletedSuccessfully, workInFlight, workWaitingInMailbox, !workWaitingToProcess);
+            boolean result = workIsWaitingToBeCompletedSuccessfully || workInFlight || workWaitingInMailbox || !workWaitingToProcess;
+        }
 
         // todo disable - commit frequency takes care of lingering? is this outdated?
         return false;

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/state/ProcessingShard.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/state/ProcessingShard.java
@@ -156,16 +156,23 @@ public class ProcessingShard<K, V> {
     }
 
     private void addToSlowWorkMaybe(Set<WorkContainer<?, ?>> slowWork, WorkContainer<?, ?> workContainer) {
-        var msgTemplate = "Can't take as work: Work ({}). Must all be true: Delay passed= {}. Is not in flight= {}. Has not succeeded already= {}. Time spent in execution queue: {}.";
         Duration timeInFlight = workContainer.getTimeInFlight();
-        var msg = msg(msgTemplate, workContainer, workContainer.isDelayPassed(), workContainer.isNotInFlight(), !workContainer.isUserFunctionSucceeded(), timeInFlight);
         Duration slowThreshold = options.getThresholdForTimeSpendInQueueWarning();
         if (isGreaterThan(timeInFlight, slowThreshold)) {
             slowWork.add(workContainer);
-            log.trace("Work has spent over " + slowThreshold + " in queue! " + msg);
+            if (log.isTraceEnabled()){
+                log.trace("Work has spent over " + slowThreshold + " in queue! " + cantTakeAsWorkMsg(workContainer, timeInFlight));
+            }
         } else {
-            log.trace(msg);
+            if (log.isTraceEnabled()) {
+                log.trace(cantTakeAsWorkMsg(workContainer, timeInFlight));
+            }
         }
+    }
+
+    private static String cantTakeAsWorkMsg(WorkContainer<?, ?> workContainer, Duration timeInFlight) {
+        var msgTemplate = "Can't take as work: Work ({}). Must all be true: Delay passed= {}. Is not in flight= {}. Has not succeeded already= {}. Time spent in execution queue: {}.";
+        return msg(msgTemplate, workContainer, workContainer.isDelayPassed(), workContainer.isNotInFlight(), !workContainer.isUserFunctionSucceeded(), timeInFlight);
     }
 
     private boolean isOrderRestricted() {

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/state/WorkManager.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/state/WorkManager.java
@@ -131,13 +131,14 @@ public class WorkManager<K, V> implements ConsumerRebalanceListener {
         var work = sm.getWorkIfAvailable(requestedMaxWorkToRetrieve);
 
         //
-        log.debug("Got {} of {} requested records of work. In-flight: {}, Awaiting in commit (partition) queues: {}",
-                work.size(),
-                requestedMaxWorkToRetrieve,
-                getNumberRecordsOutForProcessing(),
-                getNumberOfIncompleteOffsets());
+        if (log.isDebugEnabled()) {
+            log.debug("Got {} of {} requested records of work. In-flight: {}, Awaiting in commit (partition) queues: {}",
+                    work.size(),
+                    requestedMaxWorkToRetrieve,
+                    getNumberRecordsOutForProcessing(),
+                    getNumberOfIncompleteOffsets());
+        }
         numberRecordsOutForProcessing += work.size();
-
         return work;
     }
 


### PR DESCRIPTION
The "Can't take as work ..." trace message is created even when trace logging is not enabled. In our profiler we saw that this generates a significant amount of garbage. This PR only generates the message if trace logging is enabled.

### Checklist

- [ ] Documentation (if applicable)
- [ ] Changelog