### PR TITLE
Fix deadlock between pc-control and pc-broker-poll threads where partitions are revoked 

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -19,6 +19,7 @@ endif::[]
 === Fixes
 
 * fix: RunLength offset decoding returns 0 base offset after no-progress commit - related to (#546)
+* fix: Transactional PConsumer stuck while rebalancing - related to (#541)
 
 == 0.5.2.5
 

--- a/README.adoc
+++ b/README.adoc
@@ -1317,6 +1317,7 @@ endif::[]
 === Fixes
 
 * fix: RunLength offset decoding returns 0 base offset after no-progress commit - related to (#546)
+* fix: Transactional PConsumer stuck while rebalancing - related to (#541)
 
 == 0.5.2.5
 

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/internal/AbstractParallelEoSStreamProcessor.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/internal/AbstractParallelEoSStreamProcessor.java
@@ -356,9 +356,11 @@ public abstract class AbstractParallelEoSStreamProcessor<K, V> implements Parall
      * <p>
      * Make sure the calling thread is the thread which performs commit - i.e. is the {@link OffsetCommitter}.
      */
+    @SneakyThrows
     @Override
     public void onPartitionsRevoked(Collection<TopicPartition> partitions) {
         log.debug("Partitions revoked {}, state: {}", partitions, state);
+        maybeAcquireCommitLock();
         numberOfAssignedPartitions = numberOfAssignedPartitions - partitions.size();
 
         try {

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/internal/AbstractParallelEoSStreamProcessor.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/internal/AbstractParallelEoSStreamProcessor.java
@@ -164,7 +164,6 @@ public abstract class AbstractParallelEoSStreamProcessor<K, V> implements Parall
      * @see #processWorkCompleteMailBox
      */
     private final AtomicBoolean currentlyPollingWorkCompleteMailBox = new AtomicBoolean();
-
     private final OffsetCommitter committer;
 
     /**
@@ -351,6 +350,7 @@ public abstract class AbstractParallelEoSStreamProcessor<K, V> implements Parall
         consumer.subscribe(pattern, this);
     }
 
+    AtomicBoolean isRebalanceInProgress = new AtomicBoolean(false);
     /**
      * Commit our offsets
      * <p>
@@ -360,19 +360,35 @@ public abstract class AbstractParallelEoSStreamProcessor<K, V> implements Parall
     @Override
     public void onPartitionsRevoked(Collection<TopicPartition> partitions) {
         log.debug("Partitions revoked {}, state: {}", partitions, state);
-        maybeAcquireCommitLock();
+        isRebalanceInProgress.set(true);
+        while (this.producerManager.map(ProducerManager::isTransactionCommittingInProgress).orElse(false))
+            Thread.sleep(100); //wait for the transaction to finish committing
+
+        // wait for the commit transaction to complete
         numberOfAssignedPartitions = numberOfAssignedPartitions - partitions.size();
 
         try {
             // commit any offsets from revoked partitions BEFORE truncation
+            this.producerManager.ifPresent(pm -> {
+                  try{
+                        pm.preAcquireOffsetsToCommit();
+                    } catch (ConcurrentModificationException exc) {
+                        log.warn("Concurrent modification exception while pre-acquiring offsets to commit {}", exc);
+                        throw exc;
+                    } catch (Exception exc){
+                        throw new InternalRuntimeException(exc);
+                    }
+            });
+
             commitOffsetsThatAreReady();
 
             // truncate the revoked partitions
             wm.onPartitionsRevoked(partitions);
         } catch (Exception e) {
             throw new InternalRuntimeException("onPartitionsRevoked event error", e);
+        } finally {
+            isRebalanceInProgress.set(false);
         }
-
         //
         try {
             usersConsumerRebalanceListener.ifPresent(listener -> listener.onPartitionsRevoked(partitions));
@@ -679,7 +695,6 @@ public abstract class AbstractParallelEoSStreamProcessor<K, V> implements Parall
                                    Consumer<R> callback) throws TimeoutException, ExecutionException, InterruptedException {
         maybeWakeupPoller();
 
-        //
         final boolean shouldTryCommitNow = maybeAcquireCommitLock();
 
         // make sure all work that's been completed are arranged ready for commit
@@ -750,7 +765,7 @@ public abstract class AbstractParallelEoSStreamProcessor<K, V> implements Parall
      * @return true if committing should either way be attempted now
      */
     private boolean maybeAcquireCommitLock() throws TimeoutException, InterruptedException {
-        final boolean shouldTryCommitNow = isTimeToCommitNow() && wm.isDirty();
+        final boolean shouldTryCommitNow = isTimeToCommitNow() && wm.isDirty() && !isRebalanceInProgress.get();
         // could do this optimistically as well, and only get the lock if it's time to commit, so is not frequent
         if (shouldTryCommitNow && options.isUsingTransactionCommitMode()) {
             // get into write lock queue, so that no new work can be started from here on
@@ -1142,36 +1157,45 @@ public abstract class AbstractParallelEoSStreamProcessor<K, V> implements Parall
     protected <R> List<ParallelConsumer.Tuple<ConsumerRecord<K, V>, R>> runUserFunction(Function<PollContextInternal<K, V>, List<R>> usersFunction,
                                                                                         Consumer<R> callback,
                                                                                         List<WorkContainer<K, V>> workContainerBatch) {
-        if (log.isDebugEnabled()) {
-            // first offset of the batch
-            MDC.put(MDC_WORK_CONTAINER_DESCRIPTOR, workContainerBatch.get(0).offset() + "");
-        }
-        log.trace("Pool received: {}", workContainerBatch);
-
-        /*
-         *  Handle stale work from the batch, before creating the internal context for running user function.
-         *  The context created is used by the "wrapped" user function to inject transactional producer synchronization.
-         */
-        final boolean containsStaleWork = wm.checkIfWorkIsStale(workContainerBatch);
-
-        if (containsStaleWork) {
-            handleStaleWork(workContainerBatch);
-        }
-
-        final List<WorkContainer<K, V>> activeWorkContainers = containsStaleWork ?
-                workContainerBatch
-                        .stream()
-                        .filter(wc -> !wm.checkIfWorkIsStale(wc))
-                        .collect(Collectors.toList())
-                : workContainerBatch;
-
-        final PollContextInternal<K, V> context = new PollContextInternal<>(activeWorkContainers);
+        // call the user's function
+        List<R> resultsFromUserFunction;
+        PollContextInternal<K, V> context = new PollContextInternal<>(workContainerBatch);
 
         try {
-            if (!activeWorkContainers.isEmpty()) {
-                return runUserFunctionInternal(usersFunction, context, callback, activeWorkContainers);
+            if (log.isDebugEnabled()) {
+                // first offset of the batch
+                MDC.put(MDC_WORK_CONTAINER_DESCRIPTOR, workContainerBatch.get(0).offset() + "");
             }
-            return Collections.emptyList();
+            log.trace("Pool received: {}", workContainerBatch);
+
+            //
+            boolean workIsStale = wm.checkIfWorkIsStale(workContainerBatch);
+            if (workIsStale) {
+                // when epoch's change, we can't remove them from the executor pool queue, so we just have to skip them when we find them
+                log.debug("Pool found work from old generation of assigned work, skipping message as epoch doesn't match current {}", workContainerBatch);
+                return null;
+            }
+
+            resultsFromUserFunction = usersFunction.apply(context);
+
+            for (final WorkContainer<K, V> kvWorkContainer : workContainerBatch) {
+                onUserFunctionSuccess(kvWorkContainer, resultsFromUserFunction);
+            }
+
+            // capture each result, against the input record
+            var intermediateResults = new ArrayList<Tuple<ConsumerRecord<K, V>, R>>();
+            for (R result : resultsFromUserFunction) {
+                log.trace("Running users call back...");
+                callback.accept(result);
+            }
+
+            // fail or succeed, either way we're done
+            for (var kvWorkContainer : workContainerBatch) {
+                addToMailBoxOnUserFunctionSuccess(context, kvWorkContainer, resultsFromUserFunction);
+            }
+            log.trace("User function future registered");
+
+            return intermediateResults;
         } catch (Exception e) {
             // handle fail
             var cause = e.getCause();
@@ -1189,59 +1213,8 @@ public abstract class AbstractParallelEoSStreamProcessor<K, V> implements Parall
             }
             throw e; // trow again to make the future failed
         } finally {
-            cleanUpContext(context);
+            context.getProducingLock().ifPresent(ProducerManager.ProducingLock::unlock);
         }
-    }
-
-    /**
-     * Given the batch of work containers, publish stale work to feedback loop to be reduced from in progress work.
-     *
-     * @param workContainerBatch
-     */
-    protected void handleStaleWork(final List<WorkContainer<K, V>> workContainerBatch) {
-        final List<WorkContainer<K, V>> staleWorkContainers = workContainerBatch
-                .stream()
-                .filter(wm::checkIfWorkIsStale)
-                .collect(Collectors.toList());
-        final PollContextInternal<K, V> internalContext = new PollContextInternal<>(staleWorkContainers);
-        try {
-            // when epoch's change, we can't remove them from the executor pool queue, so we just have to skip them when we find them
-            log.debug("Pool found work from old generation of assigned work, skipping message as epoch doesn't match current {}", staleWorkContainers);
-            staleWorkContainers.forEach(wc -> addToMailbox(internalContext, wc));
-        } finally {
-            cleanUpContext(internalContext);
-        }
-    }
-
-    protected <R> ArrayList<Tuple<ConsumerRecord<K, V>, R>> runUserFunctionInternal(final Function<PollContextInternal<K, V>, List<R>> usersFunction,
-                                                                                    final PollContextInternal<K, V> context,
-                                                                                    final Consumer<R> callback,
-                                                                                    final List<WorkContainer<K, V>> activeWorkContainers) {
-        List<R> resultsFromUserFunction;
-        resultsFromUserFunction = usersFunction.apply(context);
-
-        for (final WorkContainer<K, V> kvWorkContainer : activeWorkContainers) {
-            onUserFunctionSuccess(kvWorkContainer, resultsFromUserFunction);
-        }
-
-        // capture each result, against the input record
-        var intermediateResults = new ArrayList<Tuple<ConsumerRecord<K, V>, R>>();
-        for (R result : resultsFromUserFunction) {
-            log.trace("Running users call back...");
-            callback.accept(result);
-        }
-
-        // fail or succeed, either way we're done
-        for (var kvWorkContainer : activeWorkContainers) {
-            addToMailBoxOnUserFunctionSuccess(context, kvWorkContainer, resultsFromUserFunction);
-        }
-        log.trace("User function future registered");
-
-        return intermediateResults;
-    }
-
-    private void cleanUpContext(final PollContextInternal<K, V> context) {
-        context.getProducingLock().ifPresent(ProducerManager.ProducingLock::unlock);
     }
 
     protected void addToMailBoxOnUserFunctionSuccess(PollContextInternal<K, V> context, WorkContainer<K, V> wc, List<?> resultsFromUserFunction) {

--- a/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/RebalanceEoSDeadlockTest.java
+++ b/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/RebalanceEoSDeadlockTest.java
@@ -1,0 +1,140 @@
+
+/*-
+ * Copyright (C) 2020-2023 Confluent, Inc.
+ */
+package io.confluent.parallelconsumer.integrationTests;
+
+import io.confluent.csid.utils.ThreadUtils;
+import io.confluent.parallelconsumer.ParallelConsumerOptions;
+import io.confluent.parallelconsumer.ParallelEoSStreamProcessor;
+import io.confluent.parallelconsumer.integrationTests.utils.KafkaClientUtils;
+import io.confluent.parallelconsumer.internal.PCModule;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.RepeatedTest;
+import pl.tlinkowski.unij.api.UniLists;
+import pl.tlinkowski.unij.api.UniSets;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static io.confluent.parallelconsumer.ParallelConsumerOptions.ProcessingOrder.PARTITION;
+import static io.confluent.parallelconsumer.integrationTests.utils.KafkaClientUtils.GroupOption.REUSE_GROUP;
+import static java.time.Duration.ofSeconds;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.number.OrderingComparison.greaterThan;
+
+/**
+ * Originally created to reproduce the bug #541 https://github.com/confluentinc/parallel-consumer/issues/541
+ * <p>
+ * This test reproduces the potential deadlock situation when a rebalance occurs
+ * using EoS with transactional producer configuration.
+ * The solution aims to avoid the deadlock by reordering the acquisition of locks
+ * in the {@link io.confluent.parallelconsumer.internal.AbstractParallelEoSStreamProcessor#onPartitionsRevoked(Collection)} method.
+ *
+ * @author Nacho Munoz
+ */
+@Slf4j
+class RebalanceEoSDeadlockTest extends BrokerIntegrationTest<String, String> {
+
+    private static final String PC_CONTROL = "pc-control";
+    public static final String PC_BROKER_POLL = "pc-broker-poll";
+    Consumer<String, String> consumer;
+    Producer<String, String> producer;
+
+    CountDownLatch rebalanceLatch;
+    private long sleepTimeMs = 0L;
+
+    ParallelEoSStreamProcessor<String, String> pc;
+
+    {
+        super.numPartitions = 2;
+    }
+
+    private String outputTopic;
+    @BeforeEach
+    void setup() {
+        rebalanceLatch = new CountDownLatch(1);
+        setupTopic();
+        outputTopic = setupTopic("output-topic");
+        producer = getKcu().createNewProducer(KafkaClientUtils.ProducerMode.TRANSACTIONAL);
+        consumer = getKcu().createNewConsumer(KafkaClientUtils.GroupOption.NEW_GROUP);
+        var pcOptions = ParallelConsumerOptions.<String,String>builder()
+                .commitMode(ParallelConsumerOptions.CommitMode.PERIODIC_TRANSACTIONAL_PRODUCER)
+                .consumer(consumer)
+                .produceLockAcquisitionTimeout(Duration.ofMinutes(2))
+                .producer(producer)
+                .ordering(PARTITION) // just so we dont need to use keys
+                .build();
+
+        pc = new ParallelEoSStreamProcessor<>(pcOptions, new PCModule<>(pcOptions)) {
+
+            @Override
+            protected void commitOffsetsThatAreReady() throws TimeoutException, InterruptedException {
+                final var threadName = Thread.currentThread().getName();
+                if (threadName.contains(PC_CONTROL)) {
+                    log.info("Delaying pc-control thread {}ms to force the potential deadlock on rebalance", sleepTimeMs);
+                    ThreadUtils.sleepQuietly(sleepTimeMs);
+                }
+
+                super.commitOffsetsThatAreReady();
+
+                if (threadName.contains(PC_BROKER_POLL)) {
+                    // onPartitionsRevoked managed to commit the offsets
+                    rebalanceLatch.countDown();
+                }
+            }
+            @Override
+            public void onPartitionsRevoked(Collection<TopicPartition> partitions) {
+                super.onPartitionsRevoked(partitions);
+            }
+        };
+
+        pc.subscribe(UniSets.of(topic));
+    }
+    final static long SLEEP_TIME_MS = 3000L;
+    @SneakyThrows
+    @RepeatedTest(5)
+    void noDeadlockOnRevoke() {
+        this.sleepTimeMs = (long) (SLEEP_TIME_MS + (Math.random() * 1000));
+        var numberOfRecordsToProduce = 100L;
+        var count = new AtomicLong();
+
+        getKcu().produceMessages(topic, numberOfRecordsToProduce);
+        pc.setTimeBetweenCommits(ofSeconds(1));
+        // consume some records
+        pc.pollAndProduce((recordContexts) -> {
+            count.getAndIncrement();
+            log.debug("Processed record, count now {} - offset: {}", count, recordContexts.offset());
+            return new ProducerRecord<>(outputTopic, recordContexts.key(), recordContexts.value());
+        });
+
+        await().timeout(Duration.ofSeconds(30)).untilAtomic(count,is(greaterThan(5L)));
+        log.debug("Records are getting consumed");
+
+        // cause rebalance
+        final Duration newPollTimeout = Duration.ofSeconds(5);
+        log.debug("Creating new consumer in same group and subscribing to same topic set with a no record timeout of {}, expect this phase to take entire timeout...", newPollTimeout);
+        try (var newConsumer = getKcu().createNewConsumer(REUSE_GROUP)) {
+            newConsumer.subscribe(UniLists.of(topic));
+            newConsumer.poll(newPollTimeout);
+
+            if (!rebalanceLatch.await(30, TimeUnit.SECONDS)) {
+                Assertions.fail("Rebalance did not finished");
+            }
+            log.debug("Test finished");
+        }
+
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/confluentinc/parallel-consumer/issues/541
![image](https://user-images.githubusercontent.com/3109377/219112744-7d247677-e6ff-42e3-a18e-171266f5912d.png)
 
### Checklist

- [x] Documentation (if applicable)
- [x] Changelog