### PR TITLE
fix: runlength decoding after no-progress commit

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -14,6 +14,12 @@ ifndef::github_name[]
 toc::[]
 endif::[]
 
+== 0.5.2.6
+
+=== Fixes
+
+* fix: RunLength offset decoding returns 0 base offset after no-progress commit - related to (#546)
+
 == 0.5.2.5
 
 === Fixes

--- a/README.adoc
+++ b/README.adoc
@@ -1312,6 +1312,12 @@ ifndef::github_name[]
 toc::[]
 endif::[]
 
+== 0.5.2.6
+
+=== Fixes
+
+* fix: RunLength offset decoding returns 0 base offset after no-progress commit - related to (#546)
+
 == 0.5.2.5
 
 === Fixes
@@ -1363,11 +1369,13 @@ endif::[]
 ** build(deps-dev): bump Confluent Platform Kafka Broker to 7.2.2 (#421)
 ** build(deps): Upgrade to AK 3.3.0 (#309)
 
+
 === Fixes
 
 * fixes #419: NoSuchElementException during race condition in PartitionState (#422)
 * Fixes #412: ClassCastException with retryDelayProvider (#417)
 * fixes ShardManager retryQueue ordering and set issues due to poor Comparator implementation (#423)
+
 
 == v0.5.2.2
 

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/offsets/OffsetRunLength.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/offsets/OffsetRunLength.java
@@ -1,7 +1,7 @@
 package io.confluent.parallelconsumer.offsets;
 
 /*-
- * Copyright (C) 2020-2022 Confluent, Inc.
+ * Copyright (C) 2020-2023 Confluent, Inc.
  */
 
 import io.confluent.parallelconsumer.offsets.OffsetMapCodecManager.HighestOffsetAndIncompletes;
@@ -83,7 +83,14 @@ public class OffsetRunLength {
 
         final var incompletes = new TreeSet<Long>();
 
-        long highestSeenOffset = 0L;
+        /*
+        Set highestSeenOffset to baseOffset -1 initially - in case the metadata doesn't actually contain any data and
+        highestSeenOffset would remain at 0 otherwise.
+        That may cause warning / state truncation.
+        Issue #546 - https://github.com/confluentinc/parallel-consumer/issues/546
+         */
+        //TODO: look at offset encoding logic - maybe in those cases we should not create metadata at all?
+        long highestSeenOffset = (baseOffset > 0) ? (baseOffset - 1) : 0L;
 
         Supplier<Boolean> hasRemainingTest = () -> {
             return switch (encoding.version) {

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/state/PartitionState.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/state/PartitionState.java
@@ -323,11 +323,12 @@ public class PartitionState<K, V> {
 
         if (pollAboveExpected) {
             // previously committed offset record has been removed from the topic, so we need to truncate up to it
-            log.warn("Truncating state - removing records lower than {} from partition {}. Offsets have been removed from the partition " +
+            log.warn("Truncating state - removing records lower than {} from partition {} of topic {}. Offsets have been removed from the partition " +
                             "by the broker or committed offset has been raised. Bootstrap polled {} but expected {} from loaded commit data. " +
                             "Could be caused by record retention or compaction and offset reset policy LATEST.",
                     bootstrapPolledOffset,
                     this.tp.partition(),
+                    this.tp.topic(),
                     bootstrapPolledOffset,
                     expectedBootstrapRecordOffset);
 
@@ -336,10 +337,12 @@ public class PartitionState<K, V> {
             incompletesToPrune.forEach(incompleteOffsets::remove);
         } else if (pollBelowExpected) {
             // reset to lower offset detected, so we need to reset our state to match
-            log.warn("Bootstrap polled offset has been reset to an earlier offset ({}) - truncating state - all records " +
+            log.warn("Bootstrap polled offset has been reset to an earlier offset ({}) for partition {} of topic {} - truncating state - all records " +
                             "above (including this) will be replayed. Was expecting {} but bootstrap poll was {}. " +
                             "Could be caused by record retention or compaction and offset reset policy EARLIEST.",
                     bootstrapPolledOffset,
+                    this.tp.partition(),
+                    this.tp.topic(),
                     expectedBootstrapRecordOffset,
                     bootstrapPolledOffset
             );


### PR DESCRIPTION
When offset data is serialized using RunLength encoder - and base offset to commit is same as the next expected offset - 1 (or lower) - basically there is no extended metadata to encode - could be caused by slow processing (slower than consumption) or on rebalance etc.

When that data is subsequently decoded - the HighestOffset is returned as 0 - that causes the warning about state truncation to be shown and the bootstrap state truncation logic to be invoked.

This fix addresses the decoding side - initializing the HighestOffset = baseOffset-1 - same as bitset decoder, but potentially we could detect and skip encoding of metadata in those scenarios - need to dig deeper and can be done as follow up.

Related issue #546 

### Checklist

- [x] Documentation (if applicable)
- [x] Changelog