### PR TITLE
PL-176 handle close dont drain mode gracefully

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -21,6 +21,7 @@ endif::[]
 
 === Fixes
 
+* fix: Don't drain mode shutdown kills inflight threads (#559)
 * fix: Drain mode shutdown doesn't pause consumption correctly (#552)
 * fix: RunLength offset decoding returns 0 base offset after no-progress commit - related to (#546)
 * fix: Transactional PConsumer stuck while rebalancing - related to (#541)

--- a/README.adoc
+++ b/README.adoc
@@ -1520,6 +1520,7 @@ endif::[]
 
 === Fixes
 
+* fix: Don't drain mode shutdown kills inflight threads (#559)
 * fix: Drain mode shutdown doesn't pause consumption correctly (#552)
 * fix: RunLength offset decoding returns 0 base offset after no-progress commit - related to (#546)
 * fix: Transactional PConsumer stuck while rebalancing - related to (#541)

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/ParallelConsumerOptions.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/ParallelConsumerOptions.java
@@ -477,4 +477,18 @@ public class ParallelConsumerOptions<K, V> {
     public boolean isProducerSupplied() {
         return getProducer() != null;
     }
+
+    /**
+     * Timeout for shutting down execution pool during shutdown in DONT_DRAIN mode. Should be high enough to allow
+     * for inflight messages to finish processing, but low enough to kill any blocked thread to allow to rebalance in a timely manner,
+     * especially if shutting down on error.
+     */
+    @Builder.Default
+    public final Duration shutdownTimeout = Duration.ofSeconds(10);
+
+    /**
+     * Timeout for draining queue during shutdown in DRAIN mode. Should be high enough to allow for all queued messages to process.
+     */
+    @Builder.Default
+    public final Duration drainTimeout = Duration.ofSeconds(30);
 }

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/internal/AbstractParallelEoSStreamProcessor.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/internal/AbstractParallelEoSStreamProcessor.java
@@ -730,12 +730,12 @@ public abstract class AbstractParallelEoSStreamProcessor<K, V> implements Parall
                     controlLoop(userFunctionWrapped, callback);
                 } catch (InterruptedException e) {
                     log.debug("Control loop interrupted, closing");
-                 //   Thread.interrupted(); //clear interrupted flag as during close need to acquire commit locks and interrupted flag will cause it to throw another interrupted exception.
+                    Thread.interrupted(); //clear interrupted flag as during close need to acquire commit locks and interrupted flag will cause it to throw another interrupted exception.
                     doClose(shutdownTimeout);
                 } catch (Exception e) {
-                 //   if (Thread.interrupted()) { //clear interrupted flag
-                 //       log.debug("Thread interrupted flag cleared in control loop error handling");
-                 //   }
+                    if (Thread.interrupted()) { //clear interrupted flag
+                        log.debug("Thread interrupted flag cleared in control loop error handling");
+                    }
                     log.error("Error from poll control thread, will attempt controlled shutdown, then rethrow. Error: " + e.getMessage(), e);
                     failureReason = new RuntimeException("Error from poll control thread: " + e.getMessage(), e);
                     doClose(shutdownTimeout); // attempt to close

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/internal/AbstractParallelEoSStreamProcessor.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/internal/AbstractParallelEoSStreamProcessor.java
@@ -730,12 +730,12 @@ public abstract class AbstractParallelEoSStreamProcessor<K, V> implements Parall
                     controlLoop(userFunctionWrapped, callback);
                 } catch (InterruptedException e) {
                     log.debug("Control loop interrupted, closing");
-                    Thread.interrupted(); //clear interrupted flag as during close need to acquire commit locks and interrupted flag will cause it to throw another interrupted exception.
+                 //   Thread.interrupted(); //clear interrupted flag as during close need to acquire commit locks and interrupted flag will cause it to throw another interrupted exception.
                     doClose(shutdownTimeout);
                 } catch (Exception e) {
-                    if (Thread.interrupted()) { //clear interrupted flag
-                        log.debug("Thread interrupted flag cleared in control loop error handling");
-                    }
+                 //   if (Thread.interrupted()) { //clear interrupted flag
+                 //       log.debug("Thread interrupted flag cleared in control loop error handling");
+                 //   }
                     log.error("Error from poll control thread, will attempt controlled shutdown, then rethrow. Error: " + e.getMessage(), e);
                     failureReason = new RuntimeException("Error from poll control thread: " + e.getMessage(), e);
                     doClose(shutdownTimeout); // attempt to close

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/internal/BrokerPollSystem.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/internal/BrokerPollSystem.java
@@ -8,7 +8,6 @@ import io.confluent.parallelconsumer.ParallelConsumerOptions;
 import io.confluent.parallelconsumer.ParallelConsumerOptions.CommitMode;
 import io.confluent.parallelconsumer.metrics.PCMetrics;
 import io.confluent.parallelconsumer.metrics.PCMetricsDef;
-import io.micrometer.core.instrument.Tag;
 import io.confluent.parallelconsumer.state.WorkManager;
 import io.micrometer.core.instrument.Gauge;
 import lombok.Getter;
@@ -27,6 +26,7 @@ import java.util.Set;
 import java.util.concurrent.*;
 
 import static io.confluent.csid.utils.StringUtils.msg;
+import static io.confluent.parallelconsumer.internal.AbstractParallelEoSStreamProcessor.DEFAULT_TIMEOUT;
 import static io.confluent.parallelconsumer.internal.AbstractParallelEoSStreamProcessor.MDC_INSTANCE_ID;
 import static io.confluent.parallelconsumer.internal.State.*;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -179,7 +179,7 @@ public class BrokerPollSystem<K, V> implements OffsetCommitter {
     private void maybeCloseConsumerManager() {
         if (isResponsibleForCommits()) {
             log.debug("Closing {}, first closing consumer...", this.getClass().getSimpleName());
-            this.consumerManager.close(DrainingCloseable.DEFAULT_TIMEOUT);
+            this.consumerManager.close(DEFAULT_TIMEOUT);
             log.debug("Consumer closed.");
         }
     }
@@ -271,7 +271,7 @@ public class BrokerPollSystem<K, V> implements OffsetCommitter {
             boolean interrupted = true;
             while (interrupted) {
                 try {
-                    Boolean pollShutdownSuccess = pollControlResult.get(DrainingCloseable.DEFAULT_TIMEOUT.toMillis(), MILLISECONDS);
+                    Boolean pollShutdownSuccess = pollControlResult.get(DEFAULT_TIMEOUT.toMillis(), MILLISECONDS);
                     interrupted = false;
                     if (!pollShutdownSuccess) {
                         log.warn("Broker poll control thread not closed cleanly.");

--- a/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/TransactionTimeoutsTest.java
+++ b/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/TransactionTimeoutsTest.java
@@ -24,14 +24,18 @@ import org.apache.kafka.common.TopicPartition;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 
+import java.time.Duration;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
 
 import static io.confluent.parallelconsumer.ManagedTruth.assertThat;
 import static io.confluent.parallelconsumer.integrationTests.utils.KafkaClientUtils.GroupOption.NEW_GROUP;
@@ -52,9 +56,16 @@ import static pl.tlinkowski.unij.api.UniLists.of;
 @Slf4j
 class TransactionTimeoutsTest extends BrokerIntegrationTest<String, String> {
 
-    public static final int NUMBER_TO_SEND = 5;
+    private static final int NUMBER_TO_SEND = 5;
 
-    public static final int SMALL_TIMEOUT = 2;
+    private static final int SMALL_TIMEOUT_MULTIPLIER = 2;
+    private static final int LONG_TIMEOUT_MULTIPLIER = 50;
+
+    private static final int OFFSET_TO_ERROR = 12;
+
+    // allow the first offsets to succeed, which we can test
+    private static final int OFFSET_TO_GO_SLOW = NUMBER_TO_SEND + 3;
+
 
     private ParallelEoSStreamProcessor<String, String> pc;
 
@@ -89,6 +100,11 @@ class TransactionTimeoutsTest extends BrokerIntegrationTest<String, String> {
                 .allowEagerProcessingDuringTransactionCommit(true);
     }
 
+    static Stream<Arguments> commitTimeoutParams() {
+        return Stream.of(Arguments.of(SMALL_TIMEOUT_MULTIPLIER, OFFSET_TO_ERROR, List.of(OFFSET_TO_ERROR)),
+                Arguments.of(LONG_TIMEOUT_MULTIPLIER, OFFSET_TO_GO_SLOW, List.of(OFFSET_TO_GO_SLOW, OFFSET_TO_ERROR)));
+    }
+
     /**
      * Tests what happens with the commit stage times out.
      * <p>
@@ -103,45 +119,42 @@ class TransactionTimeoutsTest extends BrokerIntegrationTest<String, String> {
      * <p>
      * 50: triggers a timeout with a much longer deadlock
      *
-     * @param multiple Multiple values - but affect is the same. It's not worth trying to artifically create a scneario
+     * @param multiple Multiple values - but affect is the same. It's not worth trying to artificially create a scenario
      *                 where the sleep wakes up /after/ the commit lock has timed out - this would affectively be a semi
      *                 happy path, where the result record is produced, in time for the shutdown commit, or times out
      *                 the shutdown commit as well and so the transaction doesn't get committed and will eventually
      *                 abort:
      *                 <p>
-     *                 Small value: triggers a timeout, but gets committed in the shutdown commit, with the incomplete
-     *                 offsets correct - as the sleep gets interrupted by the shutdown process (and so result record
-     *                 never produced), marked as failed and committed as such.
+     *                 Small value: triggers a timeout, but gets committed in the shutdown commit, since sleep is
+     *                 shorter than shutdown timeout - result record is produced and committed as completed.
      *                 <p>
-     *                 Large value: same as the small version, as the sleep is also interrupted.
+     *                 Large value: same as the small version, but since sleep is longer than the shutdown timeout -
+     *                 sleep gets interrupted and committed as incomplete - result record never produced, marked as
+     *                 failed and committed as such.
      */
     @SneakyThrows
     @ParameterizedTest()
-    @ValueSource(ints = {
-            SMALL_TIMEOUT,
-            50
-    })
-    void commitTimeout(int multiple) {
+    @MethodSource("commitTimeoutParams")
+    void commitTimeout(int multiple, int expectedHighestSucceededCommittedOffset, List<Integer> expectedIncompletes) {
         var options = createOptions()
+                .shutdownTimeout(Duration.ofSeconds(5))
                 .allowEagerProcessingDuringTransactionCommit(false)
                 .build();
         setup(new PCModule<>(options));
 
-        // allow the first offsets to succeed, which we can test
-        final int offsetToGoVerySlow = NUMBER_TO_SEND + 3;
+
 
         String outputTopic = getTopic() + "-output";
-        int offsetToError = 12;
 
         pc.pollAndProduce(recordContexts -> {
             log.debug("Processing {}", recordContexts.offset());
             long offset = recordContexts.offset();
-            if (offset == offsetToGoVerySlow) {
+            if (offset == OFFSET_TO_GO_SLOW) {
                 // triggers deadlock as controller can't acquire commit lock fast enough due to this sleeping thread
-                log.debug("Processing offset {} - simulating a long processing phase with timeout multiple {}", offsetToGoVerySlow, multiple);
+                log.debug("Processing offset {} - simulating a long processing phase with timeout multiple {}", OFFSET_TO_GO_SLOW, multiple);
                 ThreadUtils.sleepQuietly(1000 * multiple);
-                log.debug("Processing offset {} - simulating a long processing phase COMPLETE", offsetToGoVerySlow);
-            } else if (offset == offsetToError) {
+                log.debug("Processing offset {} - simulating a long processing phase COMPLETE", OFFSET_TO_GO_SLOW);
+            } else if (offset == OFFSET_TO_ERROR) {
                 throw new FakeRuntimeException("fail");
             }
             return new ProducerRecord<>(outputTopic, "output-value,source-offset: " + offset);
@@ -157,16 +170,19 @@ class TransactionTimeoutsTest extends BrokerIntegrationTest<String, String> {
         pc.requestCommitAsap();
 
         // wait until pc dies from commit timeout
-        await().untilAsserted(() -> assertThat(pc).isClosedOrFailed());
+        await().atMost(Duration.ofSeconds(35)).untilAsserted(() -> assertThat(pc).isClosedOrFailed());
         assertThat(pc).getFailureCause().hasMessageThat().contains("timeout");
 
         // check what was committed at shutdown to the input topic, re-using same group id as PC, to access what was committed at shutdown commit attempt
         // 2nd commit attempt during shutdown will have succeeded
         var newConsumer = getKcu().createNewConsumer(originalGroupId);
+
         var assertCommittedToPartition = assertThat(newConsumer).hasCommittedToPartition(getTopic(), partitionNumber);
 
-        assertCommittedToPartition.offset(offsetToGoVerySlow);
-        assertCommittedToPartition.encodedIncomplete(offsetToGoVerySlow, offsetToError);
+        assertCommittedToPartition.offset(expectedHighestSucceededCommittedOffset);
+        //Check that incompletes match expected - either just failed offset (for case where processing finishes during shutdown timeout)
+        // or both offsetToError and offsetToGoVerySlow for case when sleep is longer than shutdown timeout and processing is interrupted by forced thread shutdown.
+        assertCommittedToPartition.encodedIncomplete(expectedIncompletes.stream().mapToInt(x->x).toArray());
     }
 
     /**

--- a/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/TransactionTimeoutsTest.java
+++ b/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/TransactionTimeoutsTest.java
@@ -1,7 +1,7 @@
 package io.confluent.parallelconsumer.integrationTests;
 
 /*-
- * Copyright (C) 2020-2022 Confluent, Inc.
+ * Copyright (C) 2020-2023 Confluent, Inc.
  */
 
 import com.google.common.truth.Truth;

--- a/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/TransactionTimeoutsTest.java
+++ b/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/TransactionTimeoutsTest.java
@@ -31,10 +31,12 @@ import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static io.confluent.parallelconsumer.ManagedTruth.assertThat;
@@ -101,8 +103,8 @@ class TransactionTimeoutsTest extends BrokerIntegrationTest<String, String> {
     }
 
     static Stream<Arguments> commitTimeoutParams() {
-        return Stream.of(Arguments.of(SMALL_TIMEOUT_MULTIPLIER, OFFSET_TO_ERROR, List.of(OFFSET_TO_ERROR)),
-                Arguments.of(LONG_TIMEOUT_MULTIPLIER, OFFSET_TO_GO_SLOW, List.of(OFFSET_TO_GO_SLOW, OFFSET_TO_ERROR)));
+        return Stream.of(Arguments.of(SMALL_TIMEOUT_MULTIPLIER, OFFSET_TO_ERROR, listOf(OFFSET_TO_ERROR)),
+                Arguments.of(LONG_TIMEOUT_MULTIPLIER, OFFSET_TO_GO_SLOW, listOf(OFFSET_TO_GO_SLOW, OFFSET_TO_ERROR)));
     }
 
     /**
@@ -275,6 +277,10 @@ class TransactionTimeoutsTest extends BrokerIntegrationTest<String, String> {
 
         // assert output topic
         assertConsumer.assertConsumedAtLeastOffset(OUTPUT_TOPIC, NUMBER_TO_SEND + EXTRA_TO_SEND); // happy path after retry, all records committed and read ok
+    }
+
+    static List<Integer> listOf (int... ints){
+        return Arrays.stream(ints).boxed().collect(Collectors.toList());
     }
 
 }

--- a/parallel-consumer-core/src/test/java/io/confluent/parallelconsumer/ParallelEoSStreamProcessorTest.java
+++ b/parallel-consumer-core/src/test/java/io/confluent/parallelconsumer/ParallelEoSStreamProcessorTest.java
@@ -1,7 +1,7 @@
 package io.confluent.parallelconsumer;
 
 /*-
- * Copyright (C) 2020-2022 Confluent, Inc.
+ * Copyright (C) 2020-2023 Confluent, Inc.
  */
 
 import io.confluent.csid.utils.JavaUtils;

--- a/parallel-consumer-core/src/test/java/io/confluent/parallelconsumer/internal/ProducerManagerTest.java
+++ b/parallel-consumer-core/src/test/java/io/confluent/parallelconsumer/internal/ProducerManagerTest.java
@@ -41,6 +41,7 @@ import static io.confluent.parallelconsumer.ManagedTruth.assertWithMessage;
 import static io.confluent.parallelconsumer.ParallelConsumerOptions.CommitMode.PERIODIC_TRANSACTIONAL_PRODUCER;
 import static io.confluent.parallelconsumer.internal.ProducerWrapper.ProducerState.*;
 import static java.time.Duration.ofSeconds;
+import static java.util.Collections.emptyList;
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -81,8 +82,6 @@ class ProducerManagerTest {
     private void setup(ParallelConsumerOptions.ParallelConsumerOptionsBuilder<String, String> optionsBuilder) {
         opts = optionsBuilder.build();
 
-        buildModule(opts);
-
         module = buildModule(opts);
 
         mu = new ModelUtils(module);
@@ -105,7 +104,7 @@ class ProducerManagerTest {
                         }
 
                         @Override
-                        public void close(final Duration timeout, final DrainingMode drainMode) {
+                        public void close() {
                         }
                     };
                 }

--- a/parallel-consumer-core/src/test/java/io/confluent/parallelconsumer/internal/ProducerManagerTest.java
+++ b/parallel-consumer-core/src/test/java/io/confluent/parallelconsumer/internal/ProducerManagerTest.java
@@ -1,7 +1,7 @@
 package io.confluent.parallelconsumer.internal;
 
 /*-
- * Copyright (C) 2020-2022 Confluent, Inc.
+ * Copyright (C) 2020-2023 Confluent, Inc.
  */
 
 import com.google.common.truth.Truth;


### PR DESCRIPTION
Handle close dont drain mode gracefully.
Addresses issue - #559 

Added ParallelConsumerOptions shutdownTimeout - shutdown timeout is used during closeDontDrain shutdown - but because that is invoked on error as well - this option allows to set the timeout during PC creation.
Added ParallelConsumerOptions drainTimeout - to allow to specify time bound for draining the queues separately from shutdown timeout.
### Checklist

- [ ] Documentation (if applicable)
- [x] Changelog