### PR TITLE
minor: Change Supplier -> SupplierUtils for consistency

### DIFF
--- a/parallel-consumer-core/src/main/java/io/confluent/csid/utils/SupplierUtils.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/csid/utils/SupplierUtils.java
@@ -4,14 +4,14 @@ package io.confluent.csid.utils;
  * Copyright (C) 2020-2023 Confluent, Inc.
  */
 
+import lombok.experimental.UtilityClass;
+
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
-public class Suppliers {
-
-    private Suppliers() {
-    }
+@UtilityClass
+public class SupplierUtils {
 
     public static <T> Supplier<T> memoize(Supplier<T> delegate) {
         Objects.requireNonNull(delegate);

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/internal/AbstractParallelEoSStreamProcessor.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/internal/AbstractParallelEoSStreamProcessor.java
@@ -4,7 +4,7 @@ package io.confluent.parallelconsumer.internal;
  * Copyright (C) 2020-2023 Confluent, Inc.
  */
 
-import io.confluent.csid.utils.Suppliers;
+import io.confluent.csid.utils.SupplierUtils;
 import io.confluent.csid.utils.TimeUtils;
 import io.confluent.parallelconsumer.*;
 import io.confluent.parallelconsumer.metrics.PCMetrics;
@@ -290,7 +290,7 @@ public abstract class AbstractParallelEoSStreamProcessor<K, V> implements Parall
 
         this.dynamicExtraLoadFactor = module.dynamicExtraLoadFactor();
 
-        workerThreadPool = Suppliers.memoize(() -> setupWorkerPool(newOptions.getMaxConcurrency()));
+        workerThreadPool = SupplierUtils.memoize(() -> setupWorkerPool(newOptions.getMaxConcurrency()));
 
         this.wm = module.workManager();
 

--- a/parallel-consumer-core/src/test/java/io/confluent/csid/utils/SupplierUtilsTest.java
+++ b/parallel-consumer-core/src/test/java/io/confluent/csid/utils/SupplierUtilsTest.java
@@ -11,12 +11,12 @@ import java.util.function.Supplier;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class SuppliersTest {
+public class SupplierUtilsTest {
 
     @Test
     public void testMemoize() {
         UnderlyingSupplier underlyingSupplier = new UnderlyingSupplier();
-        Supplier<Integer> memoizedSupplier = Suppliers.memoize(underlyingSupplier);
+        Supplier<Integer> memoizedSupplier = SupplierUtils.memoize(underlyingSupplier);
         assertEquals(0, underlyingSupplier.calls); // the underlying supplier hasn't executed yet
         assertEquals(5, (int) memoizedSupplier.get());
 
@@ -28,20 +28,20 @@ public class SuppliersTest {
 
     @Test
     public void testMemoizeNullSupplier() {
-        assertThrows(NullPointerException.class, () -> Suppliers.memoize(null));
+        assertThrows(NullPointerException.class, () -> SupplierUtils.memoize(null));
     }
 
     @Test
     public void testMemoizeSupplierReturnsNull() {
         assertThrows(NullPointerException.class, () -> {
-            Supplier<?> supplier = Suppliers.memoize(() -> null);
+            Supplier<?> supplier = SupplierUtils.memoize(() -> null);
             supplier.get();
         });
     }
 
     @Test
     public void testMemoizeExceptionThrown() {
-        Supplier<Integer> memoizedSupplier = Suppliers.memoize(new ThrowingSupplier());
+        Supplier<Integer> memoizedSupplier = SupplierUtils.memoize(new ThrowingSupplier());
         assertThrows(IllegalStateException.class, memoizedSupplier::get);
     }
 


### PR DESCRIPTION
Change `Suppliers` utils class to `SupplierUtils` since all other utils ends with xxxUtils postfix.

https://github.com/confluentinc/parallel-consumer/tree/master/parallel-consumer-core/src/main/java/io/confluent/csid/utils

<img width="260" alt="Screen Shot 2023-08-06 at 18 33 40" src="https://github.com/confluentinc/parallel-consumer/assets/24649991/a1591741-a2d4-4fc0-a413-ad2ad9516d95">

### Checklist

- [ ] Documentation (if applicable)
- [ ] Changelog