### PR TITLE
fix : for issue 606 : exclude stale containers from counting

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -14,6 +14,11 @@ ifndef::github_name[]
 toc::[]
 endif::[]
 
+== 0.5.2.7
+
+=== Fixes
+* fix: Parallel consumer stops processing data sometimes (#606)
+
 == 0.5.2.6
 === Improvements
 

--- a/README.adoc
+++ b/README.adoc
@@ -1513,6 +1513,12 @@ ifndef::github_name[]
 toc::[]
 endif::[]
 
+== 0.5.2.7
+
+=== Fixes
+* fix: Parallel consumer stops processing data sometimes (#606)
+
+
 == 0.5.2.6
 === Improvements
 

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/state/ProcessingShard.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/state/ProcessingShard.java
@@ -79,6 +79,8 @@ public class ProcessingShard<K, V> {
     public long getCountOfWorkAwaitingSelection() {
         return entries.values().stream()
                 // todo missing pm.isBlocked(topicPartition) ?
+                // exclude stale workContainers from counting
+                .filter(workContainer -> !pm.getPartitionState(workContainer).checkIfWorkIsStale(workContainer))
                 .filter(WorkContainer::isAvailableToTakeAsWork)
                 .count();
     }


### PR DESCRIPTION
Description...
This is the fix for https://github.com/confluentinc/parallel-consumer/issues/606

The issue happens when rebalancing and partitions got re-assigned:
1. The `workcontainer` will be marked as stale container since its epoch is mismatch between `partitionsAssignmentEpoch` of `PartitionState` and `epoch` from `WorkContainer`
2. `inFlight` of `WorkContainer` will be stay false since they will be filtered to be selected in `runUserFunction` in `AbstractParallelEoSStreamProcessor`
3. The consumer paused will be triggered since if the number of staled messages are big enough `isSufficientlyLoaded`  in `WorkManager` will return true.
4. Since the staled `workcontainer` can never be selected to run user function. The consumer will be paused infinitely until next-time rebalancing

The proposed solution:
1. We should exclude those stale workcontainers from calculation


### Checklist

- [ ] Documentation (if applicable)
- [x] Changelog