### PR TITLE
fix : for issue 606 : exclude stale containers from counting and add remove add remove staled work containers function in ProcessingShard

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -14,6 +14,12 @@ ifndef::github_name[]
 toc::[]
 endif::[]
 
+== 0.5.2.7
+
+=== Fixes
+* fix: Parallel consumer stops processing data sometimes (#606)
+
+
 == 0.5.2.6
 === Improvements
 

--- a/README.adoc
+++ b/README.adoc
@@ -1513,6 +1513,11 @@ ifndef::github_name[]
 toc::[]
 endif::[]
 
+== 0.5.2.7
+
+=== Fixes
+* fix: Parallel consumer stops processing data sometimes (#606)
+
 == 0.5.2.6
 === Improvements
 

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/state/PartitionStateManager.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/state/PartitionStateManager.java
@@ -121,6 +121,11 @@ public class PartitionStateManager<K, V> implements ConsumerRebalanceListener {
             var partitionStates = om.loadPartitionStateForAssignment(assignedPartitions);
             this.partitionStates.putAll(partitionStates);
             initPartitionCounters(assignedPartitions);
+
+            // remove stale work containers after partition epoch changed
+            // because we will judge if container is stale or not by comparing between
+            // epoch from WorkContainer to partitionsAssignmentEpoch in PartitionState
+            sm.removeStaleContainers();
         } catch (Exception e) {
             log.error("Error in onPartitionsAssigned", e);
             throw e;
@@ -175,6 +180,11 @@ public class PartitionStateManager<K, V> implements ConsumerRebalanceListener {
         incrementPartitionAssignmentEpoch(partitions);
         resetOffsetMapAndRemoveWork(partitions);
         deregisterPartitionCounters(partitions);
+
+        // remove stale work containers after partition epoch changed
+        // because we will judge if container is stale or not by comparing between
+        // epoch from WorkContainer to partitionsAssignmentEpoch in PartitionState
+        sm.removeStaleContainers();
     }
 
     /**

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/state/ProcessingShard.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/state/ProcessingShard.java
@@ -122,7 +122,6 @@ public class ProcessingShard<K, V> {
         while (workTaken.size() < workToGetDelta && iterator.hasNext()) {
             var workContainer = iterator.next().getValue();
 
-
             if (pm.couldBeTakenAsWork(workContainer)) {
                 if (workContainer.isAvailableToTakeAsWork()) {
                     log.trace("Taking {} as work", workContainer);

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/state/ProcessingShard.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/state/ProcessingShard.java
@@ -79,8 +79,6 @@ public class ProcessingShard<K, V> {
     public long getCountOfWorkAwaitingSelection() {
         return entries.values().stream()
                 // todo missing pm.isBlocked(topicPartition) ?
-                // exclude stale workContainers from counting
-                .filter(workContainer -> !isWorkContainerStale(workContainer))
                 .filter(WorkContainer::isAvailableToTakeAsWork)
                 .count();
     }

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/state/ShardManager.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/state/ShardManager.java
@@ -270,6 +270,16 @@ public class ShardManager<K, V> {
         return workFromAllShards;
     }
 
+    public boolean removeStaleContainers() {
+        boolean removed = processingShards.values().stream()
+                .map(ProcessingShard::removeStaleWorkContainersFromShard)
+                .anyMatch(res -> res.equals(true));
+        if (removed) {
+            log.debug("there are stale work containers removed");
+        }
+        return removed;
+    }
+
     private void updateResumePoint(Optional<Map.Entry<ShardKey, ProcessingShard<K, V>>> lastShard) {
         // if empty, iteration was exhausted and no resume point is needed
         iterationResumePoint = lastShard.map(Map.Entry::getKey);


### PR DESCRIPTION
Description...
This is the fix for https://github.com/confluentinc/parallel-consumer/issues/606

The issue happens when rebalancing and partitions got re-assigned:
1. The `workcontainer` will be marked as stale container since its epoch is mismatch between `partitionsAssignmentEpoch` of `PartitionState` and `epoch` from `WorkContainer`
https://github.com/confluentinc/parallel-consumer/blob/master/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/state/PartitionState.java#L655

2. `inFlight` of `WorkContainer` will be stay false since they will be filtered to be selected in `runUserFunction` in `AbstractParallelEoSStreamProcessor`
https://github.com/confluentinc/parallel-consumer/blob/master/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/internal/AbstractParallelEoSStreamProcessor.java#L1256

3. The consumer paused will be triggered since if the number of staled messages are big enough `isSufficientlyLoaded`  in `WorkManager` will return true.
https://github.com/confluentinc/parallel-consumer/blob/master/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/state/WorkManager.java#L232C1-L232C1
https://github.com/confluentinc/parallel-consumer/blob/master/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/state/WorkContainer.java#L230

4. Since the staled `workcontainer` can never be selected to run user function. The consumer will be paused infinitely until next-time rebalancing
https://github.com/confluentinc/parallel-consumer/blob/master/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/internal/BrokerPollSystem.java#L304

5. Meanwhile, while `getWorkIfAvailable` in `WorkManager` will try to extract active workcontainers, but since the staled containers have the lower offsets, they will be extracted always earlier than the new ones. (if the same partitions have been assigned to the consumer again). Then the new records have no chances to be processed since the it will break out of the while loop.
https://github.com/confluentinc/parallel-consumer/blob/master/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/state/ProcessingShard.java#L134

The proposed solution:
1. We should exclude those stale work containers from calculation
2. remove staled work containers from shard when partition assigned and revoke happen


### Checklist

- [ ] Documentation (if applicable)
- [x] Changelog