### PR TITLE
fix readme doc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1211,10 +1211,10 @@ Following example illustrates setup of Parallel Consumer with Meter Registry and
         return eosStreamProcessor;
     }
 ----
-<1> - Optional - Kafka Consumer Micrometer metrics object created for Kafka Consumer that is later used for Parallel Consumer.
-<2> - Optional - Kafka Consumer Micrometer metrics are bound to Meter Registry.
-<3> - Meter Registry is set through ParallelConsumerOptions.builder(), if not specified - will default to CompositeMeterRegistry - which is No-op.
-<4> - Optional - "instance" tag with value of "pc1" is set through same builder - it will be added to all Parallel Consumer meters
+<1> - Meter Registry is set through ParallelConsumerOptions.builder(), if not specified - will default to CompositeMeterRegistry - which is No-op.
+<2> - Optional - "instance" tag with value of "pc1" is set through same builder - it will be added to all Parallel Consumer meters
+<3> - Optional - Kafka Consumer Micrometer metrics object created for Kafka Consumer that is later used for Parallel Consumer.
+<4> - Optional - Kafka Consumer Micrometer metrics are bound to Meter Registry.
 
 NOTE:: any additional binders / metrics need to be cleaned up appropriately - for example the Kafka Consumer Metrics registered above - need to be closed using `kafkaClientMetrics.close()` after calling shutting down Parallel Consumer as Parallel Consumer will close Kafka Consumer on shutdown.
 
@@ -1516,6 +1516,8 @@ endif::[]
 == 0.5.2.7
 
 === Fixes
+
+* fix: Return cached pausedPartitionSet (#618)
 * fix: Parallel consumer stops processing data sometimes (#606)
 
 == 0.5.2.6

--- a/src/docs/README_TEMPLATE.adoc
+++ b/src/docs/README_TEMPLATE.adoc
@@ -963,10 +963,10 @@ Following example illustrates setup of Parallel Consumer with Meter Registry and
 ----
 include::{project_root}/parallel-consumer-examples/parallel-consumer-example-metrics/src/main/java/io/confluent/parallelconsumer/examples/metrics/CoreApp.java[tag=example]
 ----
-<1> - Optional - Kafka Consumer Micrometer metrics object created for Kafka Consumer that is later used for Parallel Consumer.
-<2> - Optional - Kafka Consumer Micrometer metrics are bound to Meter Registry.
-<3> - Meter Registry is set through ParallelConsumerOptions.builder(), if not specified - will default to CompositeMeterRegistry - which is No-op.
-<4> - Optional - "instance" tag with value of "pc1" is set through same builder - it will be added to all Parallel Consumer meters
+<1> - Meter Registry is set through ParallelConsumerOptions.builder(), if not specified - will default to CompositeMeterRegistry - which is No-op.
+<2> - Optional - "instance" tag with value of "pc1" is set through same builder - it will be added to all Parallel Consumer meters
+<3> - Optional - Kafka Consumer Micrometer metrics object created for Kafka Consumer that is later used for Parallel Consumer.
+<4> - Optional - Kafka Consumer Micrometer metrics are bound to Meter Registry.
 
 NOTE:: any additional binders / metrics need to be cleaned up appropriately - for example the Kafka Consumer Metrics registered above - need to be closed using `kafkaClientMetrics.close()` after calling shutting down Parallel Consumer as Parallel Consumer will close Kafka Consumer on shutdown.
 


### PR DESCRIPTION
In ReadMe. it introduce the metric function.
```
    var options = ParallelConsumerOptions.<String, String>builder()
            .ordering(ParallelConsumerOptions.ProcessingOrder.KEY)
            .maxConcurrency(1000)
            .consumer(kafkaConsumer)
            .meterRegistry(meterRegistry)                     //(1)
            .metricsTags(Tags.of(Tag.of("instance", "pc1")))    //(2)
            .build();

......
    kafkaClientMetrics = new KafkaClientMetrics(kafkaConsumer); //(3)
    kafkaClientMetrics.bindTo(meterRegistry);                 //(4)
```
with gloss
```
1. Optional - Kafka Consumer Micrometer metrics object created for Kafka Consumer that is later used for Parallel Consumer.

2. Optional - Kafka Consumer Micrometer metrics are bound to Meter Registry.

3. Meter Registry is set through ParallelConsumerOptions.builder(), if not specified - will default to CompositeMeterRegistry - which is No-op.

4. Optional - "instance" tag with value of "pc1" is set through same builder - it will be added to all Parallel Consumer meters
```
I think the actual sequence should be 3,4,1,2


i'm not sure whether should modify this file, i cannot execute ``mvn asciidoc-template::build`` in my own pc.