### PR TITLE
PL-464 remove micrometer-atlas dependency

### DIFF
--- a/parallel-consumer-core/pom.xml
+++ b/parallel-consumer-core/pom.xml
@@ -40,10 +40,6 @@
             <artifactId>micrometer-core</artifactId>
             <scope>compile</scope>
         </dependency>
-        <dependency>
-            <groupId>io.micrometer</groupId>
-            <artifactId>micrometer-registry-atlas</artifactId>
-        </dependency>
 
         <!-- Testing -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -115,8 +115,6 @@
         <truth-generator-maven-plugin.version>0.1.1</truth-generator-maven-plugin.version>
         <jabel.version>1.0.0</jabel.version>
         <micrometer-core.version>1.10.2</micrometer-core.version>
-        <micrometer-registry-atlas.version>1.9.5</micrometer-registry-atlas.version>
-
     </properties>
 
     <profiles>
@@ -394,11 +392,6 @@
                 <groupId>io.micrometer</groupId>
                 <artifactId>micrometer-core</artifactId>
                 <version>${micrometer-core.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.micrometer</groupId>
-                <artifactId>micrometer-registry-atlas</artifactId>
-                <version>${micrometer-registry-atlas.version}</version>
             </dependency>
             <!-- External -->
             <dependency>


### PR DESCRIPTION
Remove micrometer-atlas dependency. 
It is causing issues in Spring as it autoconfigures use of Atlas registry which may not be present and causes attempts to send metrics that fail with warnings.

It was added by mistake and not actually needed. 
### Checklist

- [ ] Documentation (if applicable)
- [X] Changelog