### PR TITLE
Fix/refactor metrics singleton

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -25,6 +25,7 @@ endif::[]
 
 * fix: Return cached pausedPartitionSet (#618)
 * fix: Parallel consumer stops processing data sometimes (#606)
+* fix: Refactor metrics implementation to not use singleton - allows correct metrics subsystem operation when multiple parallel consumer instances are running in same java process, fixes (#617) improves on (#627)
 
 == 0.5.2.6
 === Improvements

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -17,15 +17,10 @@ endif::[]
 
 === Fixes
 
-* fix: Add synchronization to ensure proper intializaiton and closing of PCMetrics singleton. (#617)
-
-== 0.5.2.7
-
-=== Fixes
-
 * fix: Return cached pausedPartitionSet (#618)
 * fix: Parallel consumer stops processing data sometimes (#606)
-* fix: Refactor metrics implementation to not use singleton - allows correct metrics subsystem operation when multiple parallel consumer instances are running in same java process, fixes (#617) improves on (#627)
+* fix: Add synchronization to ensure proper intializaiton and closing of PCMetrics singleton. (#617)
+* fix: Refactor metrics implementation to not use singleton - allows correct metrics subsystem operation when multiple parallel consumer instances are running in same java process (#630), fixes (#617) improves on (#627)
 
 == 0.5.2.6
 === Improvements

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -20,7 +20,7 @@ endif::[]
 * fix: Return cached pausedPartitionSet (#618)
 * fix: Parallel consumer stops processing data sometimes (#606)
 * fix: Add synchronization to ensure proper intializaiton and closing of PCMetrics singleton. (#617)
-* fix: Refactor metrics implementation to not use singleton - allows correct metrics subsystem operation when multiple parallel consumer instances are running in same java process (#630), fixes (#617) improves on (#627)
+* fix: Refactor metrics implementation to not use singleton - improves meter separation, allows correct metrics subsystem operation when multiple parallel consumer instances are running in same java process (#630), fixes (#617) improves on (#627)
 
 == 0.5.2.6
 === Improvements

--- a/README.adoc
+++ b/README.adoc
@@ -1192,13 +1192,14 @@ Following example illustrates setup of Parallel Consumer with Meter Registry and
 ----
     ParallelStreamProcessor<String, String> setupParallelConsumer() {
         Consumer<String, String> kafkaConsumer = getKafkaConsumer();
-
+        String instanceId = UUID.randomUUID().toString();
         var options = ParallelConsumerOptions.<String, String>builder()
                 .ordering(ParallelConsumerOptions.ProcessingOrder.KEY)
                 .maxConcurrency(1000)
                 .consumer(kafkaConsumer)
                 .meterRegistry(meterRegistry)                     //<1>
-                .metricsTags(Tags.of(Tag.of("instance", "pc1")))    //<2>
+                .metricsTags(Tags.of(Tag.of("common-tag", "tag1")))    //<2>
+                .pcInstanceTag(instanceId)                          //<3>
                 .build();
 
         ParallelStreamProcessor<String, String> eosStreamProcessor =
@@ -1206,15 +1207,16 @@ Following example illustrates setup of Parallel Consumer with Meter Registry and
 
         eosStreamProcessor.subscribe(of(inputTopic));
 
-        kafkaClientMetrics = new KafkaClientMetrics(kafkaConsumer); //<3>
-        kafkaClientMetrics.bindTo(meterRegistry);                 //<4>
+        kafkaClientMetrics = new KafkaClientMetrics(kafkaConsumer); //<4>
+        kafkaClientMetrics.bindTo(meterRegistry);                 //<5>
         return eosStreamProcessor;
     }
 ----
 <1> - Meter Registry is set through ParallelConsumerOptions.builder(), if not specified - will default to CompositeMeterRegistry - which is No-op.
-<2> - Optional - "instance" tag with value of "pc1" is set through same builder - it will be added to all Parallel Consumer meters
-<3> - Optional - Kafka Consumer Micrometer metrics object created for Kafka Consumer that is later used for Parallel Consumer.
-<4> - Optional - Kafka Consumer Micrometer metrics are bound to Meter Registry.
+<2> - Optional - common tags can be specified through same builder - they will be added to all Parallel Consumer meters
+<3> - Optional - instance tag value can be specified - it has to be unique to ensure meter uniqueness in cases when multiple parallel consumer instances are recording metrics to the same meter registry. If instance tag is not specified - unique UUID value will be generated and used. Tag is created with tag key 'pcinstance'.
+<4> - Optional - Kafka Consumer Micrometer metrics object created for Kafka Consumer that is later used for Parallel Consumer.
+<5> - Optional - Kafka Consumer Micrometer metrics are bound to Meter Registry.
 
 NOTE:: any additional binders / metrics need to be cleaned up appropriately - for example the Kafka Consumer Metrics registered above - need to be closed using `kafkaClientMetrics.close()` after calling shutting down Parallel Consumer as Parallel Consumer will close Kafka Consumer on shutdown.
 
@@ -1512,13 +1514,14 @@ NOTE:: Dependency version bumps are not listed here.
 ifndef::github_name[]
 toc::[]
 endif::[]
-
 == 0.5.2.7
 
 === Fixes
 
 * fix: Return cached pausedPartitionSet (#618)
 * fix: Parallel consumer stops processing data sometimes (#606)
+* fix: Add synchronization to ensure proper intializaiton and closing of PCMetrics singleton. (#617)
+* fix: Refactor metrics implementation to not use singleton - allows correct metrics subsystem operation when multiple parallel consumer instances are running in same java process (#630), fixes (#617) improves on (#627)
 
 == 0.5.2.6
 === Improvements

--- a/README.adoc
+++ b/README.adoc
@@ -1521,7 +1521,7 @@ endif::[]
 * fix: Return cached pausedPartitionSet (#618)
 * fix: Parallel consumer stops processing data sometimes (#606)
 * fix: Add synchronization to ensure proper intializaiton and closing of PCMetrics singleton. (#617)
-* fix: Refactor metrics implementation to not use singleton - allows correct metrics subsystem operation when multiple parallel consumer instances are running in same java process (#630), fixes (#617) improves on (#627)
+* fix: Refactor metrics implementation to not use singleton - improves meter separation, allows correct metrics subsystem operation when multiple parallel consumer instances are running in same java process (#630), fixes (#617) improves on (#627)
 
 == 0.5.2.6
 === Improvements

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/ParallelConsumerOptions.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/ParallelConsumerOptions.java
@@ -20,6 +20,7 @@ import org.apache.kafka.common.annotation.InterfaceStability;
 
 import java.time.Duration;
 import java.util.Objects;
+import java.util.UUID;
 import java.util.function.Function;
 
 import static io.confluent.csid.utils.StringUtils.msg;
@@ -83,6 +84,8 @@ public class ParallelConsumerOptions<K, V> {
 
     @Builder.Default
     private final Iterable<Tag> metricsTags = Tags.empty();
+
+    private final String pcInstanceTag;
 
     /**
      * The ordering guarantee to use.

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/ParallelConsumerOptions.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/ParallelConsumerOptions.java
@@ -5,6 +5,7 @@ package io.confluent.parallelconsumer;
  */
 
 import io.confluent.parallelconsumer.internal.AbstractParallelEoSStreamProcessor;
+import io.confluent.parallelconsumer.metrics.PCMetricsDef;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
@@ -78,14 +79,24 @@ public class ParallelConsumerOptions<K, V> {
 
     /**
      * Micrometer MeterRegistry
+     * <p>
+     * Optional - if not specified CompositeMeterRegistry will be used which is NoOp
+     */
+    private final MeterRegistry meterRegistry;
+
+    /**
+     * PC Instance metrics tag value - if specified - should be unique to allow instance specific meters to be created
+     * and cleared. Used with Tag key {@link PCMetricsDef#PC_INSTANCE_TAG}
+     * <p>
+     * If not set - unique UUID will be generated for it
+     */
+    private final String pcInstanceTag;
+
+    /**
+     * Additional common metrics tags - will be added to all created meters
      */
     @Builder.Default
-    private final MeterRegistry meterRegistry = new CompositeMeterRegistry();
-
-    @Builder.Default
     private final Iterable<Tag> metricsTags = Tags.empty();
-
-    private final String pcInstanceTag;
 
     /**
      * The ordering guarantee to use.
@@ -334,8 +345,9 @@ public class ParallelConsumerOptions<K, V> {
     }
 
     /**
-     * Controls the error handling behaviour to use when invalid offsets metadata from a pre-existing consumer group is encountered.
-     * A potential scenario where this could occur is when a consumer group id from a Kafka Streams application is accidentally reused.
+     * Controls the error handling behaviour to use when invalid offsets metadata from a pre-existing consumer group is
+     * encountered. A potential scenario where this could occur is when a consumer group id from a Kafka Streams
+     * application is accidentally reused.
      * <p>
      * Default is {@link InvalidOffsetMetadataHandlingPolicy#FAIL}
      */
@@ -482,15 +494,16 @@ public class ParallelConsumerOptions<K, V> {
     }
 
     /**
-     * Timeout for shutting down execution pool during shutdown in DONT_DRAIN mode. Should be high enough to allow
-     * for inflight messages to finish processing, but low enough to kill any blocked thread to allow to rebalance in a timely manner,
-     * especially if shutting down on error.
+     * Timeout for shutting down execution pool during shutdown in DONT_DRAIN mode. Should be high enough to allow for
+     * inflight messages to finish processing, but low enough to kill any blocked thread to allow to rebalance in a
+     * timely manner, especially if shutting down on error.
      */
     @Builder.Default
     public final Duration shutdownTimeout = Duration.ofSeconds(10);
 
     /**
-     * Timeout for draining queue during shutdown in DRAIN mode. Should be high enough to allow for all queued messages to process.
+     * Timeout for draining queue during shutdown in DRAIN mode. Should be high enough to allow for all queued messages
+     * to process.
      */
     @Builder.Default
     public final Duration drainTimeout = Duration.ofSeconds(30);

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/internal/AbstractParallelEoSStreamProcessor.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/internal/AbstractParallelEoSStreamProcessor.java
@@ -43,7 +43,7 @@ import static io.confluent.csid.utils.BackportUtils.isEmpty;
 import static io.confluent.csid.utils.BackportUtils.toSeconds;
 import static io.confluent.csid.utils.StringUtils.msg;
 import static io.confluent.parallelconsumer.internal.State.*;
-import static io.confluent.parallelconsumer.metrics.PCMetricsDef.METER_PREFIX;
+import static io.confluent.parallelconsumer.metrics.PCMetricsDef.USER_FUNCTION_EXECUTOR_PREFIX;
 import static java.lang.Boolean.TRUE;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -260,6 +260,8 @@ public abstract class AbstractParallelEoSStreamProcessor<K, V> implements Parall
 
     private Duration drainTimeout;
 
+    private PCMetrics pcMetrics;
+
     protected AbstractParallelEoSStreamProcessor(ParallelConsumerOptions<K, V> newOptions) {
         this(newOptions, new PCModule<>(newOptions));
     }
@@ -286,7 +288,7 @@ public abstract class AbstractParallelEoSStreamProcessor<K, V> implements Parall
                 newOptions.getConsumer().groupMetadata().groupId(),
                 newOptions);
         //Initialize global metrics - should be initialized before any of the module objects are created so that meters can be bound in them.
-        PCMetrics.initialize(options.getMeterRegistry(), options.getMetricsTags());
+        pcMetrics = module.pcMetrics();
 
         this.dynamicExtraLoadFactor = module.dynamicExtraLoadFactor();
 
@@ -311,13 +313,13 @@ public abstract class AbstractParallelEoSStreamProcessor<K, V> implements Parall
     }
 
     private void initMetrics() {
-        this.userProcessingTimer = PCMetrics.getInstance().getTimerFromMetricDef(PCMetricsDef.USER_FUNCTION_PROCESSING_TIME);
-        this.loadFactorGauge = PCMetrics.getInstance().gaugeFromMetricDef(PCMetricsDef.DYNAMIC_EXTRA_LOAD_FACTOR,
+        this.userProcessingTimer = pcMetrics.getTimerFromMetricDef(PCMetricsDef.USER_FUNCTION_PROCESSING_TIME);
+        this.loadFactorGauge = pcMetrics.gaugeFromMetricDef(PCMetricsDef.DYNAMIC_EXTRA_LOAD_FACTOR,
                 dynamicExtraLoadFactor, DynamicLoadFactor::getCurrentFactor);
-        this.statusGauge = PCMetrics.getInstance().gaugeFromMetricDef(PCMetricsDef.PC_STATUS, this, pc -> pc.state.getValue());
+        this.statusGauge = pcMetrics.gaugeFromMetricDef(PCMetricsDef.PC_STATUS, this, pc -> pc.state.getValue());
         new ExecutorServiceMetrics(this.getWorkerThreadPool().get(), "pc-user-function-executor",
-                METER_PREFIX,
-                this.options.getMetricsTags()).bindTo(PCMetrics.getInstance().getMeterRegistry());
+                USER_FUNCTION_EXECUTOR_PREFIX,
+                pcMetrics.getCommonTags()).bindTo(pcMetrics.getMeterRegistry());
     }
 
     private void validateConfiguration() {
@@ -626,13 +628,21 @@ public abstract class AbstractParallelEoSStreamProcessor<K, V> implements Parall
         maybeCloseConsumer();
 
         producerManager.ifPresent(x -> x.close(timeout));
-        PCMetrics.close();
+        deregisterMeters();
+        pcMetrics.close();
         log.debug("Close complete.");
         this.state = CLOSED;
 
         if (this.getFailureCause() != null) {
             log.error("PC closed due to error: {}", getFailureCause(), null);
         }
+    }
+
+    /**
+     * De-registers and removes user function executor meters from meter registry on shutdown
+     */
+    private void deregisterMeters() {
+        pcMetrics.removeMetersByPrefixAndCommonTags(USER_FUNCTION_EXECUTOR_PREFIX);
     }
 
     /**

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/internal/BrokerPollSystem.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/internal/BrokerPollSystem.java
@@ -68,6 +68,8 @@ public class BrokerPollSystem<K, V> implements OffsetCommitter {
 
     private final WorkManager<K, V> wm;
 
+    private final PCMetrics pcMetrics;
+
     private Gauge statusGauge;
     private Gauge numPausedPartitionsGauge;
 
@@ -83,12 +85,13 @@ public class BrokerPollSystem<K, V> implements OffsetCommitter {
                 committer = Optional.of(consumerCommitter);
             }
         }
+        pcMetrics = pc.getModule().pcMetrics();
         initMetrics();
     }
 
     private void initMetrics() {
-        statusGauge = PCMetrics.getInstance().gaugeFromMetricDef(PCMetricsDef.PC_POLLER_STATUS, this, poller -> poller.runState.getValue());
-        numPausedPartitionsGauge = PCMetrics.getInstance().gaugeFromMetricDef(PCMetricsDef.NUM_PAUSED_PARTITIONS,
+        statusGauge = pcMetrics.gaugeFromMetricDef(PCMetricsDef.PC_POLLER_STATUS, this, poller -> poller.runState.getValue());
+        numPausedPartitionsGauge = pcMetrics.gaugeFromMetricDef(PCMetricsDef.NUM_PAUSED_PARTITIONS,
                 this.consumerManager, ConsumerManager::getPausedPartitionSize);
     }
 

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/internal/PCModule.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/internal/PCModule.java
@@ -7,6 +7,7 @@ package io.confluent.parallelconsumer.internal;
 import io.confluent.csid.utils.TimeUtils;
 import io.confluent.parallelconsumer.ParallelConsumerOptions;
 import io.confluent.parallelconsumer.ParallelEoSStreamProcessor;
+import io.confluent.parallelconsumer.metrics.PCMetrics;
 import io.confluent.parallelconsumer.state.WorkManager;
 import lombok.Setter;
 import org.apache.kafka.clients.consumer.Consumer;
@@ -105,5 +106,14 @@ public class PCModule<K, V> {
 
     public Clock clock() {
         return TimeUtils.getClock();
+    }
+
+    private PCMetrics pcMetrics;
+
+    public PCMetrics pcMetrics() {
+        if (pcMetrics == null) {
+            pcMetrics = new PCMetrics(options().getMeterRegistry(), optionsInstance.getMetricsTags(), optionsInstance.getPcInstanceTag());
+        }
+        return pcMetrics;
     }
 }

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/metrics/PCMetrics.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/metrics/PCMetrics.java
@@ -6,26 +6,28 @@ package io.confluent.parallelconsumer.metrics;
 
 import io.micrometer.core.instrument.*;
 import io.micrometer.core.instrument.Timer;
-import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import io.micrometer.core.instrument.search.Search;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.ToDoubleFunction;
 
-import static java.util.Collections.emptyList;
+import static java.util.Collections.singleton;
 
 /**
- * Main metrics collection and initialization service.
- * Singleton - makes it easier to add metrics throughout the code
+ * Main metrics collection and initialization service. Singleton - makes it easier to add metrics throughout the code
  */
 @Slf4j
 public class PCMetrics {
-    private static PCMetrics instance;
 
+    public static final String PC_INSTANCE_TAG = "pc-instance";
     /**
      * Meter registry used for metrics - set through init call on singleton initialization. Configurable through
      * Parallel Consumer Options.
      */
+    @Getter
     private MeterRegistry meterRegistry;
 
     /**
@@ -37,34 +39,62 @@ public class PCMetrics {
      * Common metrics tags added to all meters - for example PC instance. Configurable through Parallel Consumer
      * Options.
      */
+    @Getter
     private Iterable<Tag> commonTags;
 
-    private PCMetrics(MeterRegistry meterRegistry, Iterable<Tag> commonTags) {
-        this.meterRegistry = meterRegistry;
-        this.commonTags = commonTags;
-    }
+    @Getter
+    private Tag instanceTag;
+
+    private final AtomicBoolean isClosed = new AtomicBoolean(true);
 
     /**
-     * Singleton initialization - mandatory to be performed before using the singleton through {@link #getInstance()}.
-     *
      * @param meterRegistry: meterRegistry to use for meter registration - configured through
      *                       {@link io.confluent.parallelconsumer.ParallelConsumerOptions} on PC initialization
      * @param commonTags:    set of tags to add to all meters - for example - PC instance.
      */
-    public static synchronized void initialize(MeterRegistry meterRegistry, Iterable<Tag> commonTags) {
-        if(instance != null){
-            log.warn("Reinitializing PCMetrics without closing them first. Closing previous instance.");
-            close();
+    public PCMetrics(MeterRegistry meterRegistry, Iterable<Tag> commonTags, String instanceTag) {
+        this.meterRegistry = meterRegistry;
+        if (instanceTag != null) {
+            this.instanceTag = Tag.of(PC_INSTANCE_TAG, instanceTag);
+        } else {
+            this.instanceTag = generateUniqueInstanceTag();
         }
-        instance = new PCMetrics(meterRegistry, commonTags);
+        this.commonTags = combine(this.instanceTag, commonTags);
+        this.isClosed.set(false);
     }
 
-    public static PCMetrics getInstance() {
-        if (instance == null) {
-            log.warn("Warning - trying to use PCMetrics without first initializing it with MeterRegistry. Default noop meter registry will be used.");
-            initialize(new CompositeMeterRegistry(), emptyList());
-        }
-        return instance;
+    /**
+     * Combines instance tag and common tags specified while ensuring there are no tags with same tag key.
+     * @param instanceTag
+     * @param commonTags
+     * @return combined tag collection with unique tag keys
+     */
+    private Iterable<Tag> combine(Tag instanceTag, Iterable<Tag> commonTags) {
+        Set<String> tagKeys = new HashSet<>();
+        List<Tag> tags = new LinkedList<>();
+
+        tagKeys.add(instanceTag.getKey());
+        tags.add(instanceTag);
+        commonTags.forEach(tag -> {
+            if (!tagKeys.contains(tag.getKey())) {
+                tagKeys.add(tag.getKey());
+                tags.add(tag);
+            } else {
+                log.warn("Duplicate metrics tag specified : {}", tag.getKey());
+            }
+        });
+        return tags;
+    }
+
+
+    private Tag generateUniqueInstanceTag() {
+        boolean inUse;
+        Tag tagToUse;
+        do {
+            tagToUse = Tag.of(PC_INSTANCE_TAG, UUID.randomUUID().toString());
+            inUse = Search.in(meterRegistry).tags(singleton(instanceTag)).meter() != null;
+        } while (inUse);
+        return tagToUse;
     }
 
     /**
@@ -158,29 +188,22 @@ public class PCMetrics {
         return distributionSummary;
     }
 
-    public MeterRegistry getMeterRegistry() {
-        return this.meterRegistry;
-    }
-
     /**
-     * Resets the singleton instance.
+     * Closes PCMetrics object and cleans up all meters from registry - should be recreated before using it again.
      */
-    public static synchronized void close() {
-        if (instance == null) {
+    public void close() {
+        if (this.isClosed.getAndSet(true)) {
+            //Instance already closed - warn and ignore.
+            log.warn("Trying to close PCMetrics instance that is already closed.");
             return;
         }
-        log.debug("Resetting PCMetrics");
+        log.debug("Closing PCMetrics");
         // clean up the instance resources
-        MeterRegistry registry = instance.getMeterRegistry();
-        synchronized (instance.registeredMeters) {
-            instance.registeredMeters.forEach(registry::remove);
-            instance.registeredMeters.clear();
-        }
-        // clear instance
-        instance = null;
+        this.registeredMeters.forEach(this.meterRegistry::remove);
+        this.registeredMeters.clear();
     }
 
-    public static void removeMeter(Meter meter) {
+    public void removeMeter(Meter meter) {
         if (meter != null) {
             removeMeter(meter.getId());
         }
@@ -191,11 +214,24 @@ public class PCMetrics {
      *
      * @param meterId the meter id to remove.
      */
-    public static void removeMeter(Meter.Id meterId) {
-        log.debug("Removing meter: {}", meterId);
-        if (instance != null) {
-            instance.getMeterRegistry().remove(meterId);
-            instance.registeredMeters.remove(meterId);
+    public void removeMeter(Meter.Id meterId) {
+        if (this.isClosed.get()) {
+            //Already closed metrics subsystem - ignore
+            log.debug("Trying to remove meter when metrics subsystem is already closed. Meter Id {}", meterId);
+            return;
         }
+        log.debug("Removing meter: {}", meterId);
+        this.meterRegistry.remove(meterId);
+        this.registeredMeters.remove(meterId);
+    }
+
+    public void removeMetersByPrefixAndCommonTags(String meterNamePrefix) {
+        if (this.isClosed.get()) {
+            //Already closed metrics subsystem - ignore
+            log.debug("Trying to remove meters when metrics subsystem is already closed.");
+            return;
+        }
+        Search.in(meterRegistry).name(name -> name.startsWith(meterNamePrefix))
+                .tags(commonTags).meters().forEach(meterRegistry::remove);
     }
 }

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/metrics/PCMetricsDef.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/metrics/PCMetricsDef.java
@@ -60,6 +60,8 @@ public enum PCMetricsDef {
     METADATA_SPACE_USED("metadata.space.used", "Ratio between offset metadata payload size and available space", PCMetricsSubsystem.OFFSET_ENCODER, DISTRIBUTION_SUMMARY),
     PAYLOAD_RATIO_USED("payload.ratio.used", "Ratio between offset metadata payload size and offsets encoded", PCMetricsSubsystem.OFFSET_ENCODER, DISTRIBUTION_SUMMARY);
 
+    public static final String PC_INSTANCE_TAG = "pcinstance";
+
     private static String getStateToValueListing() {
         return Arrays.stream(State.values()).map(state -> state.getValue() + ":" + state).collect(Collectors.joining(", "));
     }

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/metrics/PCMetricsDef.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/metrics/PCMetricsDef.java
@@ -70,7 +70,8 @@ public enum PCMetricsDef {
 
     private static final String SUBSYSTEM_TAG_KEY = "subsystem";
 
-    public static final String METER_PREFIX = "pc.";
+    private static final String METER_PREFIX = "pc.";
+    public static final String USER_FUNCTION_EXECUTOR_PREFIX = METER_PREFIX+"user.function.";
 
     @Getter
     private final String name;

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/offsets/OffsetMapCodecManager.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/offsets/OffsetMapCodecManager.java
@@ -72,6 +72,8 @@ public class OffsetMapCodecManager<K, V> {
     private Timer offsetEncodingTimer;
     private final Map<OffsetEncoding, Counter> encodingCounters = new HashMap<>();
 
+    private final PCMetrics pcMetrics;
+
     private static ParallelConsumerOptions.InvalidOffsetMetadataHandlingPolicy errorPolicy = ParallelConsumerOptions.InvalidOffsetMetadataHandlingPolicy.FAIL;
 
     /**
@@ -115,11 +117,12 @@ public class OffsetMapCodecManager<K, V> {
         if (module != null){
             this.errorPolicy = module.options().getInvalidOffsetMetadataPolicy();
         }
+        pcMetrics = module.pcMetrics();
         initMeters();
     }
 
     private void initMeters() {
-        offsetEncodingTimer = PCMetrics.getInstance().getTimerFromMetricDef(PCMetricsDef.OFFSETS_ENCODING_TIME);
+        offsetEncodingTimer = pcMetrics.getTimerFromMetricDef(PCMetricsDef.OFFSETS_ENCODING_TIME);
     }
 
     /**
@@ -253,7 +256,7 @@ public class OffsetMapCodecManager<K, V> {
     private Counter getCounterMeterForEncoding(OffsetEncoding encoding) {
         Counter counter = encodingCounters.get(encoding);
         if (counter == null) {
-            counter = PCMetrics.getInstance().getCounterFromMetricDef(PCMetricsDef.OFFSETS_ENCODING_USAGE,
+            counter = pcMetrics.getCounterFromMetricDef(PCMetricsDef.OFFSETS_ENCODING_USAGE,
                     Tag.of("encoding", encoding.name()));
             encodingCounters.put(encoding, counter);
         }

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/state/PartitionState.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/state/PartitionState.java
@@ -170,7 +170,7 @@ public class PartitionState<K, V> {
     private Gauge ephochGauge;
     private DistributionSummary ratioPayloadUsedDistributionSummary;
     private DistributionSummary ratioMetadataSpaceUsedDistributionSummary;
-
+    private final PCMetrics pcMetrics;
 
     public PartitionState(long newEpoch,
                           PCModule<K, V> pcModule,
@@ -180,7 +180,7 @@ public class PartitionState<K, V> {
 
         this.tp = topicPartition;
         this.partitionsAssignmentEpoch = newEpoch;
-
+        this.pcMetrics = module.pcMetrics();
         initStateFromOffsetData(offsetData);
         initMetrics();
     }
@@ -665,30 +665,30 @@ public class PartitionState<K, V> {
             return;
         }
         Tag[] partitionStateTags = new Tag[]{Tag.of("topic", topicPartition.topic()), Tag.of("partition", String.valueOf(topicPartition.partition()))};
-        lastCommittedOffsetGauge = PCMetrics.getInstance().gaugeFromMetricDef(PCMetricsDef.PARTITION_LAST_COMMITTED_OFFSET,
+        lastCommittedOffsetGauge = pcMetrics.gaugeFromMetricDef(PCMetricsDef.PARTITION_LAST_COMMITTED_OFFSET,
                 this, partitionState -> partitionState.lastCommittedOffset, partitionStateTags);
-        highestSeenOffsetGauge = PCMetrics.getInstance().gaugeFromMetricDef(PCMetricsDef.PARTITION_HIGHEST_SEEN_OFFSET,
+        highestSeenOffsetGauge = pcMetrics.gaugeFromMetricDef(PCMetricsDef.PARTITION_HIGHEST_SEEN_OFFSET,
                 this, PartitionState::getOffsetHighestSeen, partitionStateTags);
-        highestCompletedOffsetGauge = PCMetrics.getInstance().gaugeFromMetricDef(PCMetricsDef.PARTITION_HIGHEST_COMPLETED_OFFSET,
+        highestCompletedOffsetGauge = pcMetrics.gaugeFromMetricDef(PCMetricsDef.PARTITION_HIGHEST_COMPLETED_OFFSET,
                 this, PartitionState::getOffsetHighestSucceeded, partitionStateTags);
-        highestSequentialSucceededOffsetGauge = PCMetrics.getInstance().gaugeFromMetricDef(PCMetricsDef.PARTITION_HIGHEST_SEQUENTIAL_SUCCEEDED_OFFSET,
+        highestSequentialSucceededOffsetGauge = pcMetrics.gaugeFromMetricDef(PCMetricsDef.PARTITION_HIGHEST_SEQUENTIAL_SUCCEEDED_OFFSET,
                 this, PartitionState::getOffsetHighestSequentialSucceeded, partitionStateTags);
-        numberOfIncompletesGauge = PCMetrics.getInstance().gaugeFromMetricDef(PCMetricsDef.PARTITION_INCOMPLETE_OFFSETS,
+        numberOfIncompletesGauge = pcMetrics.gaugeFromMetricDef(PCMetricsDef.PARTITION_INCOMPLETE_OFFSETS,
                 this, partitionState -> partitionState.incompleteOffsets.size(), partitionStateTags);
-        ephochGauge = PCMetrics.getInstance().gaugeFromMetricDef(PCMetricsDef.PARTITION_ASSIGNMENT_EPOCH,
+        ephochGauge = pcMetrics.gaugeFromMetricDef(PCMetricsDef.PARTITION_ASSIGNMENT_EPOCH,
                 this, PartitionState::getPartitionsAssignmentEpoch, partitionStateTags);
-        ratioMetadataSpaceUsedDistributionSummary = PCMetrics.getInstance().getDistributionSummaryFromMetricDef(PCMetricsDef.METADATA_SPACE_USED, partitionStateTags);
-        ratioPayloadUsedDistributionSummary = PCMetrics.getInstance().getDistributionSummaryFromMetricDef(PCMetricsDef.PAYLOAD_RATIO_USED, partitionStateTags);
+        ratioMetadataSpaceUsedDistributionSummary = pcMetrics.getDistributionSummaryFromMetricDef(PCMetricsDef.METADATA_SPACE_USED, partitionStateTags);
+        ratioPayloadUsedDistributionSummary = pcMetrics.getDistributionSummaryFromMetricDef(PCMetricsDef.PAYLOAD_RATIO_USED, partitionStateTags);
     }
 
     private void deregisterMetrics() {
-        PCMetrics.removeMeter(lastCommittedOffsetGauge);
-        PCMetrics.removeMeter(highestSeenOffsetGauge);
-        PCMetrics.removeMeter(highestCompletedOffsetGauge);
-        PCMetrics.removeMeter(highestSequentialSucceededOffsetGauge);
-        PCMetrics.removeMeter(numberOfIncompletesGauge);
-        PCMetrics.removeMeter(ephochGauge);
-        PCMetrics.removeMeter(ratioMetadataSpaceUsedDistributionSummary);
-        PCMetrics.removeMeter(ratioPayloadUsedDistributionSummary);
+        pcMetrics.removeMeter(lastCommittedOffsetGauge);
+        pcMetrics.removeMeter(highestSeenOffsetGauge);
+        pcMetrics.removeMeter(highestCompletedOffsetGauge);
+        pcMetrics.removeMeter(highestSequentialSucceededOffsetGauge);
+        pcMetrics.removeMeter(numberOfIncompletesGauge);
+        pcMetrics.removeMeter(ephochGauge);
+        pcMetrics.removeMeter(ratioMetadataSpaceUsedDistributionSummary);
+        pcMetrics.removeMeter(ratioPayloadUsedDistributionSummary);
     }
 }

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/state/ShardManager.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/state/ShardManager.java
@@ -101,10 +101,13 @@ public class ShardManager<K, V> {
     private Gauge shardsSizeGauge;
     private Gauge numberOfShardsGauge;
 
+    private final PCMetrics pcMetrics;
+
     public ShardManager(final PCModule<K, V> module, final WorkManager<K, V> wm) {
         this.module = module;
         this.wm = wm;
         this.options = module.options();
+        this.pcMetrics = module.pcMetrics();
         initMetrics();
     }
 
@@ -289,10 +292,10 @@ public class ShardManager<K, V> {
     }
 
     private void initMetrics() {
-        shardsSizeGauge = PCMetrics.getInstance().gaugeFromMetricDef(PCMetricsDef.SHARDS_SIZE,
+        shardsSizeGauge = pcMetrics.gaugeFromMetricDef(PCMetricsDef.SHARDS_SIZE,
                 this, shardManager -> shardManager.processingShards.values().stream()
                         .mapToInt(processingShard -> processingShard.getEntries().size()).sum());
-        numberOfShardsGauge = PCMetrics.getInstance().gaugeFromMetricDef(PCMetricsDef.NUMBER_OF_SHARDS,
+        numberOfShardsGauge = pcMetrics.gaugeFromMetricDef(PCMetricsDef.NUMBER_OF_SHARDS,
                 this, shardManager -> shardManager.processingShards.keySet().size());
     }
 }

--- a/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/MultiInstanceMetricsTest.java
+++ b/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/MultiInstanceMetricsTest.java
@@ -1,7 +1,8 @@
+package io.confluent.parallelconsumer.integrationTests;
+
 /*-
  * Copyright (C) 2020-2023 Confluent, Inc.
  */
-package io.confluent.parallelconsumer.integrationTests;
 
 import io.confluent.parallelconsumer.ParallelConsumerOptions;
 import io.confluent.parallelconsumer.ParallelEoSStreamProcessor;

--- a/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/MultiInstanceMetricsTest.java
+++ b/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/MultiInstanceMetricsTest.java
@@ -1,0 +1,170 @@
+/*-
+ * Copyright (C) 2020-2023 Confluent, Inc.
+ */
+package io.confluent.parallelconsumer.integrationTests;
+
+import io.confluent.csid.utils.ThreadUtils;
+import io.confluent.parallelconsumer.ParallelConsumerOptions;
+import io.confluent.parallelconsumer.ParallelEoSStreamProcessor;
+import io.confluent.parallelconsumer.integrationTests.utils.KafkaClientUtils;
+import io.confluent.parallelconsumer.internal.PCModule;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.search.Search;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.api.*;
+import pl.tlinkowski.unij.api.UniLists;
+import pl.tlinkowski.unij.api.UniSets;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static io.confluent.parallelconsumer.ParallelConsumerOptions.CommitMode.PERIODIC_CONSUMER_ASYNCHRONOUS;
+import static io.confluent.parallelconsumer.ParallelConsumerOptions.ProcessingOrder.PARTITION;
+import static io.confluent.parallelconsumer.integrationTests.utils.KafkaClientUtils.GroupOption.NEW_GROUP;
+import static io.confluent.parallelconsumer.integrationTests.utils.KafkaClientUtils.GroupOption.REUSE_GROUP;
+import static io.confluent.parallelconsumer.metrics.PCMetrics.PC_INSTANCE_TAG;
+import static io.confluent.parallelconsumer.metrics.PCMetricsDef.PROCESSED_RECORDS;
+import static java.time.Duration.ofSeconds;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.number.OrderingComparison.greaterThan;
+
+@Slf4j
+class MultiInstanceMetricsTest extends BrokerIntegrationTest<String, String> {
+    {
+        super.numPartitions = 2;
+    }
+
+    SimpleMeterRegistry simpleMeterRegistry;
+    private String outputTopic;
+
+    @BeforeEach
+    void setup() {
+        setupTopic();
+        simpleMeterRegistry = new SimpleMeterRegistry();
+    }
+
+    @AfterEach
+    void cleanup() {
+        simpleMeterRegistry.close();
+    }
+
+
+    @SneakyThrows
+    @Test
+    void twoInstancePCMetricsRecordedIndependently() {
+
+        var numberOfRecordsToProduce = 100L;
+
+        getKcu().produceMessages(topic, numberOfRecordsToProduce);
+
+        String pcInstance1Tag = UUID.randomUUID().toString();
+
+        var pcOptions = getOptions(pcInstance1Tag, NEW_GROUP);
+
+        ParallelEoSStreamProcessor<String, String> pc = new ParallelEoSStreamProcessor<>(pcOptions, new PCModule<>(pcOptions));
+        pc.subscribe(UniSets.of(topic));
+
+        String pcInstance2Tag = UUID.randomUUID().toString();
+        pcOptions = getOptions(pcInstance2Tag, REUSE_GROUP);
+
+        ParallelEoSStreamProcessor<String, String> pc2 = new ParallelEoSStreamProcessor<>(pcOptions, new PCModule<>(pcOptions));
+        pc2.subscribe(UniSets.of(topic));
+
+        AtomicInteger pc1Counter = new AtomicInteger();
+        AtomicInteger pc2Counter = new AtomicInteger();
+        pc.poll(record -> pc1Counter.incrementAndGet());
+
+        pc2.poll(record -> pc2Counter.incrementAndGet());
+
+
+        await().timeout(Duration.ofSeconds(30)).until(() -> pc1Counter.get() + pc2Counter.get() == numberOfRecordsToProduce);
+        assertThat(Search.in(simpleMeterRegistry).tag(PC_INSTANCE_TAG, pcInstance1Tag).name(PROCESSED_RECORDS.getName()).counter().count()).isEqualTo(pc1Counter.get());
+        assertThat(Search.in(simpleMeterRegistry).tag(PC_INSTANCE_TAG, pcInstance2Tag).name(PROCESSED_RECORDS.getName()).counter().count()).isEqualTo(pc2Counter.get());
+        pc.close();
+        pc2.close();
+    }
+
+    @SneakyThrows
+    @Test
+    void sameRegistryCanBeReusedAfterPcInstanceClosed() {
+
+        var numberOfRecordsToProduce = 20;
+
+        getKcu().produceMessages(topic, numberOfRecordsToProduce);
+
+
+        var pcOptions = getOptions(null, NEW_GROUP);
+
+        ParallelEoSStreamProcessor<String, String> pc = new ParallelEoSStreamProcessor<>(pcOptions, new PCModule<>(pcOptions));
+        pc.subscribe(UniSets.of(topic));
+
+
+        AtomicInteger pc1Counter = new AtomicInteger();
+        pc.poll(record -> pc1Counter.incrementAndGet());
+
+
+        await().timeout(Duration.ofSeconds(30)).until(() -> pc1Counter.get() == numberOfRecordsToProduce);
+        assertThat(Search.in(simpleMeterRegistry).name(PROCESSED_RECORDS.getName()).counters().stream().mapToDouble(Counter::count).sum()).isEqualTo(pc1Counter.get());
+        pc.close();
+
+        getKcu().produceMessages(topic, numberOfRecordsToProduce);
+
+        pcOptions = getOptions(null, NEW_GROUP);
+
+        ParallelEoSStreamProcessor<String, String> pc2 = new ParallelEoSStreamProcessor<>(pcOptions, new PCModule<>(pcOptions));
+        pc2.subscribe(UniSets.of(topic));
+        AtomicInteger pc2Counter = new AtomicInteger();
+
+        pc2.poll(record -> pc2Counter.incrementAndGet());
+        await().timeout(Duration.ofSeconds(30)).until(() -> pc2Counter.get() == numberOfRecordsToProduce * 2);
+        assertThat(Search.in(simpleMeterRegistry).name(PROCESSED_RECORDS.getName()).counters().stream().mapToDouble(Counter::count).sum()).isEqualTo(pc2Counter.get());
+
+        pc2.close();
+    }
+
+    @SneakyThrows
+    @Test
+    void allMetersRemovedFromRegistryOnClose() {
+        var numberOfRecordsToProduce = 10L;
+        getKcu().produceMessages(topic, numberOfRecordsToProduce);
+        String pcInstance1Tag = UUID.randomUUID().toString();
+
+        var pcOptions = getOptions(pcInstance1Tag, NEW_GROUP);
+
+        ParallelEoSStreamProcessor<String, String> pc = new ParallelEoSStreamProcessor<>(pcOptions, new PCModule<>(pcOptions));
+        pc.subscribe(UniSets.of(topic));
+        AtomicInteger pc1Counter = new AtomicInteger();
+        pc.poll(record -> pc1Counter.incrementAndGet());
+        await().timeout(Duration.ofSeconds(30)).until(() -> pc1Counter.get() == numberOfRecordsToProduce);
+        assertThat(Search.in(simpleMeterRegistry).tag(PC_INSTANCE_TAG, pcInstance1Tag).name(PROCESSED_RECORDS.getName()).counters().stream().mapToDouble(Counter::count).sum()).isEqualTo(pc1Counter.get());
+        pc.close();
+        assertThat(simpleMeterRegistry.getMeters().size()).isEqualTo(0);
+    }
+
+
+    ParallelConsumerOptions<String, String> getOptions(String pcInstanceTag, KafkaClientUtils.GroupOption consumerGroupOption) {
+        return ParallelConsumerOptions.<String, String>builder()
+                .commitMode(PERIODIC_CONSUMER_ASYNCHRONOUS)
+                .consumer(getKcu().createNewConsumer(consumerGroupOption))
+                .meterRegistry(simpleMeterRegistry)
+                .pcInstanceTag(pcInstanceTag)
+                .ordering(PARTITION) // just so we dont need to use keys
+                .build();
+
+    }
+}

--- a/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/MultiInstanceMetricsTest.java
+++ b/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/MultiInstanceMetricsTest.java
@@ -3,45 +3,32 @@
  */
 package io.confluent.parallelconsumer.integrationTests;
 
-import io.confluent.csid.utils.ThreadUtils;
 import io.confluent.parallelconsumer.ParallelConsumerOptions;
 import io.confluent.parallelconsumer.ParallelEoSStreamProcessor;
 import io.confluent.parallelconsumer.integrationTests.utils.KafkaClientUtils;
 import io.confluent.parallelconsumer.internal.PCModule;
 import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.search.Search;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.kafka.clients.consumer.Consumer;
-import org.apache.kafka.clients.producer.Producer;
-import org.apache.kafka.clients.producer.ProducerRecord;
-import org.apache.kafka.common.TopicPartition;
 import org.junit.jupiter.api.*;
-import pl.tlinkowski.unij.api.UniLists;
 import pl.tlinkowski.unij.api.UniSets;
 
 import java.time.Duration;
-import java.util.Collection;
 import java.util.UUID;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
 
 import static io.confluent.parallelconsumer.ParallelConsumerOptions.CommitMode.PERIODIC_CONSUMER_ASYNCHRONOUS;
 import static io.confluent.parallelconsumer.ParallelConsumerOptions.ProcessingOrder.PARTITION;
 import static io.confluent.parallelconsumer.integrationTests.utils.KafkaClientUtils.GroupOption.NEW_GROUP;
 import static io.confluent.parallelconsumer.integrationTests.utils.KafkaClientUtils.GroupOption.REUSE_GROUP;
-import static io.confluent.parallelconsumer.metrics.PCMetrics.PC_INSTANCE_TAG;
+import static io.confluent.parallelconsumer.metrics.PCMetricsDef.PC_INSTANCE_TAG;
 import static io.confluent.parallelconsumer.metrics.PCMetricsDef.PROCESSED_RECORDS;
 import static java.time.Duration.ofSeconds;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.number.OrderingComparison.greaterThan;
 
 @Slf4j
 class MultiInstanceMetricsTest extends BrokerIntegrationTest<String, String> {

--- a/parallel-consumer-core/src/test/java/io/confluent/parallelconsumer/PCMetricsTest.java
+++ b/parallel-consumer-core/src/test/java/io/confluent/parallelconsumer/PCMetricsTest.java
@@ -232,6 +232,7 @@ class PCMetricsTest extends ParallelEoSStreamProcessorTestBase {
         });
     }
 
+
     private double registeredGaugeValueFor(PCMetricsDef metricsDef, String... filterTags) {
         return Optional.ofNullable(registry.find(metricsDef.getName()).tags(filterTags).gauge()).map(Gauge::value).orElse(-1.0);
     }

--- a/parallel-consumer-core/src/test/java/io/confluent/parallelconsumer/PCMetricsTest.java
+++ b/parallel-consumer-core/src/test/java/io/confluent/parallelconsumer/PCMetricsTest.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 @Slf4j
 class PCMetricsTest extends ParallelEoSStreamProcessorTestBase {
     private SimpleMeterRegistry registry;
-    private final List<Tag> commonTags = UniLists.of(Tag.of("instance", "pc1"));
+    private final List<Tag> commonTags = UniLists.of(Tag.of("tag1", "pc1"));
 
     @Test
     @SneakyThrows

--- a/parallel-consumer-examples/parallel-consumer-example-metrics/src/main/java/io/confluent/parallelconsumer/examples/metrics/CoreApp.java
+++ b/parallel-consumer-examples/parallel-consumer-example-metrics/src/main/java/io/confluent/parallelconsumer/examples/metrics/CoreApp.java
@@ -25,6 +25,7 @@ import java.net.InetSocketAddress;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -93,13 +94,14 @@ public class CoreApp {
     // tag::example[]
     ParallelStreamProcessor<String, String> setupParallelConsumer() {
         Consumer<String, String> kafkaConsumer = getKafkaConsumer();
-
+        String instanceId = UUID.randomUUID().toString();
         var options = ParallelConsumerOptions.<String, String>builder()
                 .ordering(ParallelConsumerOptions.ProcessingOrder.KEY)
                 .maxConcurrency(1000)
                 .consumer(kafkaConsumer)
                 .meterRegistry(meterRegistry)                     //<1>
-                .metricsTags(Tags.of(Tag.of("instance", "pc1")))    //<2>
+                .metricsTags(Tags.of(Tag.of("common-tag", "tag1")))    //<2>
+                .pcInstanceTag(instanceId)                          //<3>
                 .build();
 
         ParallelStreamProcessor<String, String> eosStreamProcessor =
@@ -107,8 +109,8 @@ public class CoreApp {
 
         eosStreamProcessor.subscribe(of(inputTopic));
 
-        kafkaClientMetrics = new KafkaClientMetrics(kafkaConsumer); //<3>
-        kafkaClientMetrics.bindTo(meterRegistry);                 //<4>
+        kafkaClientMetrics = new KafkaClientMetrics(kafkaConsumer); //<4>
+        kafkaClientMetrics.bindTo(meterRegistry);                 //<5>
         return eosStreamProcessor;
     }
     // end::example[]

--- a/src/docs/README_TEMPLATE.adoc
+++ b/src/docs/README_TEMPLATE.adoc
@@ -964,9 +964,10 @@ Following example illustrates setup of Parallel Consumer with Meter Registry and
 include::{project_root}/parallel-consumer-examples/parallel-consumer-example-metrics/src/main/java/io/confluent/parallelconsumer/examples/metrics/CoreApp.java[tag=example]
 ----
 <1> - Meter Registry is set through ParallelConsumerOptions.builder(), if not specified - will default to CompositeMeterRegistry - which is No-op.
-<2> - Optional - "instance" tag with value of "pc1" is set through same builder - it will be added to all Parallel Consumer meters
-<3> - Optional - Kafka Consumer Micrometer metrics object created for Kafka Consumer that is later used for Parallel Consumer.
-<4> - Optional - Kafka Consumer Micrometer metrics are bound to Meter Registry.
+<2> - Optional - common tags can be specified through same builder - they will be added to all Parallel Consumer meters
+<3> - Optional - instance tag value can be specified - it has to be unique to ensure meter uniqueness in cases when multiple parallel consumer instances are recording metrics to the same meter registry. If instance tag is not specified - unique UUID value will be generated and used. Tag is created with tag key 'pcinstance'.
+<4> - Optional - Kafka Consumer Micrometer metrics object created for Kafka Consumer that is later used for Parallel Consumer.
+<5> - Optional - Kafka Consumer Micrometer metrics are bound to Meter Registry.
 
 NOTE:: any additional binders / metrics need to be cleaned up appropriately - for example the Kafka Consumer Metrics registered above - need to be closed using `kafkaClientMetrics.close()` after calling shutting down Parallel Consumer as Parallel Consumer will close Kafka Consumer on shutdown.
 


### PR DESCRIPTION
Refactor metrics subsytem to not use singleton - allowing to run multiple PC instances in same java process.
Introduced `pcinstance` tag that can be specified through PCOptions and is autogenerated as UUID value if not specified to ensure uniqueness of meters per PC instance.

### Checklist

- [X] Documentation (if applicable)
- [X] Changelog