### PR TITLE
Remove duplicated batchSize factor from target load; add a test case

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -15,6 +15,8 @@ toc::[]
 endif::[]
 == 0.5.2.8
 
+* fix: Fix target loading computation for inflight records
+
 === Fixes
 
 * fix: Fix equality and hash code for ShardKey with array key (#638), resolves (#579)

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/internal/AbstractParallelEoSStreamProcessor.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/internal/AbstractParallelEoSStreamProcessor.java
@@ -997,8 +997,7 @@ public abstract class AbstractParallelEoSStreamProcessor<K, V> implements Parall
 
     protected int getQueueTargetLoaded() {
         //noinspection unchecked
-        int batch = options.getBatchSize();
-        return getPoolLoadTarget() * dynamicExtraLoadFactor.getCurrentFactor() * batch;
+        return getPoolLoadTarget() * dynamicExtraLoadFactor.getCurrentFactor();
     }
 
     /**

--- a/parallel-consumer-core/src/test/java/io/confluent/parallelconsumer/AbstractParallelEoSStreamProcessorConfigurationTest.java
+++ b/parallel-consumer-core/src/test/java/io/confluent/parallelconsumer/AbstractParallelEoSStreamProcessorConfigurationTest.java
@@ -12,20 +12,20 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
- * Tests that the protected and internal methods of
+ * Tests to verify the protected and internal methods of
  * {@link io.confluent.parallelconsumer.internal.AbstractParallelEoSStreamProcessor} work as expected.
  * <p>
  *
  * @author Jonathon Koyle
  */
 @Slf4j
-class ParallelEoSStreamProcessorNonRunningTest {
+class AbstractParallelEoSStreamProcessorConfigurationTest {
 
     /**
-     * Test that the mock consumer works as expected
+     * Test that the {@link io.confluent.parallelconsumer.internal.AbstractParallelEoSStreamProcessor#getQueueTargetLoaded}
      */
     @Test
-    void getTargetLoad() {
+    void queueTargetLoad() {
         final int batchSize = 10;
         final int concurrency = 2;
         final MockConsumer<String, String> consumer = new MockConsumer<>(OffsetResetStrategy.LATEST);

--- a/parallel-consumer-core/src/test/java/io/confluent/parallelconsumer/ParallelEoSStreamProcessorNonRunningTest.java
+++ b/parallel-consumer-core/src/test/java/io/confluent/parallelconsumer/ParallelEoSStreamProcessorNonRunningTest.java
@@ -1,0 +1,39 @@
+package io.confluent.parallelconsumer;
+
+/*-
+ * Copyright (C) 2020-2023 Confluent, Inc.
+ */
+
+import io.confluent.parallelconsumer.internal.TestParallelEoSStreamProcessor;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests that the protected and internal methods of
+ * {@link io.confluent.parallelconsumer.internal.AbstractParallelEoSStreamProcessor} work as expected.
+ * <p>
+ *
+ * @author Jonathon Koyle
+ */
+@Slf4j
+class ParallelEoSStreamProcessorNonRunningTest {
+
+    /**
+     * Test that the mock consumer works as expected
+     */
+    @Test
+    void getTargetLoad() {
+        final int expectedTargetLoad = 40;
+        final ParallelConsumerOptions<String, String> testOptions = ParallelConsumerOptions.<String, String>builder()
+                .batchSize(10)
+                .maxConcurrency(2)
+                .build();
+        TestParallelEoSStreamProcessor<String, String> testInstance = new TestParallelEoSStreamProcessor<>(testOptions);
+
+        final int actualTargetLoad = testInstance.getTargetLoad();
+
+        Assertions.assertEquals(expectedTargetLoad, actualTargetLoad);
+    }
+
+}

--- a/parallel-consumer-core/src/test/java/io/confluent/parallelconsumer/internal/TestParallelEoSStreamProcessor.java
+++ b/parallel-consumer-core/src/test/java/io/confluent/parallelconsumer/internal/TestParallelEoSStreamProcessor.java
@@ -1,0 +1,19 @@
+package io.confluent.parallelconsumer.internal;
+
+/*-
+ * Copyright (C) 2020-2023 Confluent, Inc.
+ */
+
+import io.confluent.parallelconsumer.ParallelConsumerOptions;
+
+/**
+ * Provides a set of methods for testing internal and configuration based interfaces of
+ * {@link AbstractParallelEoSStreamProcessor}.
+ */
+public class TestParallelEoSStreamProcessor<K, V> extends AbstractParallelEoSStreamProcessor<K, V> {
+    public TestParallelEoSStreamProcessor(final ParallelConsumerOptions<K, V> newOptions) {
+        super(newOptions);
+    }
+
+    public int getTargetLoad() { return getQueueTargetLoaded(); }
+}


### PR DESCRIPTION
Addresses a bug identified in a slack thread (https://confluentcommunity.slack.com/archives/C051K2TJLPQ/p1699018828805729) which causes the inflight queue to scale by `batchSize * batchSize * maxConcurrency * dynamicLoadFactor` rather than `batchSize * maxConcurrency * dynamicLoadFactor`

### Checklist

- [ ] Documentation (if applicable)
- [x] Changelog