### PR TITLE
Fix synchronisation logic between commits

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -15,11 +15,10 @@ toc::[]
 endif::[]
 == 0.5.2.8
 
-* fix: Fix target loading computation for inflight records
-
 === Fixes
-
 * fix: Fix equality and hash code for ShardKey with array key (#638), resolves (#579)
+* fix: Fix target loading computation for inflight records (#662)
+* fix: Fix synchronisation logic for transactional producer commit affecting non-transactional usage (#665), resolves (#637)
 
 == 0.5.2.7
 

--- a/README.adoc
+++ b/README.adoc
@@ -1517,8 +1517,9 @@ endif::[]
 == 0.5.2.8
 
 === Fixes
-
 * fix: Fix equality and hash code for ShardKey with array key (#638), resolves (#579)
+* fix: Fix target loading computation for inflight records (#662)
+* fix: Fix synchronisation logic for transactional producer commit affecting non-transactional usage (#665), resolves (#637)
 
 == 0.5.2.7
 

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/internal/AbstractParallelEoSStreamProcessor.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/internal/AbstractParallelEoSStreamProcessor.java
@@ -408,21 +408,13 @@ public abstract class AbstractParallelEoSStreamProcessor<K, V> implements Parall
     public void onPartitionsRevoked(Collection<TopicPartition> partitions) {
         log.debug("Partitions revoked {}, state: {}", partitions, state);
         isRebalanceInProgress.set(true);
-        while (this.producerManager.map(ProducerManager::isTransactionCommittingInProgress).orElse(false))
+        while (isTransactionCommittingInProgress())
             Thread.sleep(100); //wait for the transaction to finish committing
 
         numberOfAssignedPartitions = numberOfAssignedPartitions - partitions.size();
 
         try {
             // commit any offsets from revoked partitions BEFORE truncation
-            this.producerManager.ifPresent(pm -> {
-                try {
-                    pm.preAcquireOffsetsToCommit();
-                } catch (Exception exc) {
-                    throw new InternalRuntimeException(exc);
-                }
-            });
-
             commitOffsetsThatAreReady();
 
             // truncate the revoked partitions
@@ -616,7 +608,7 @@ public abstract class AbstractParallelEoSStreamProcessor<K, V> implements Parall
         processWorkCompleteMailBox(Duration.ZERO);
 
         //
-        if( Thread.currentThread().isInterrupted()) {
+        if (Thread.currentThread().isInterrupted()) {
             log.warn("control thread interrupted - may lead to issues with transactional commit lock acquisition");
         }
         commitOffsetsThatAreReady();
@@ -1428,6 +1420,11 @@ public abstract class AbstractParallelEoSStreamProcessor<K, V> implements Parall
                 this.commitCommand.set(false);
             }
         }
+    }
+
+    private boolean isTransactionCommittingInProgress() {
+        return options.isUsingTransactionCommitMode() &&
+                producerManager.map(ProducerManager::isTransactionCommittingInProgress).orElse(false);
     }
 
     @Override

--- a/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/BrokerIntegrationTest.java
+++ b/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/BrokerIntegrationTest.java
@@ -1,11 +1,8 @@
 
 /*-
- * Copyright (C) 2020-2022 Confluent, Inc.
+ * Copyright (C) 2020-2023 Confluent, Inc.
  */
 package io.confluent.parallelconsumer.integrationTests;
-/*-
- * Copyright (C) 2020-2022 Confluent, Inc.
- */
 
 import io.confluent.csid.testcontainers.FilteredTestContainerSlf4jLogConsumer;
 import io.confluent.parallelconsumer.integrationTests.utils.KafkaClientUtils;

--- a/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/RebalanceTest.java
+++ b/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/RebalanceTest.java
@@ -4,10 +4,6 @@
  */
 package io.confluent.parallelconsumer.integrationTests;
 
-/*-
- * Copyright (C) 2020-2022 Confluent, Inc.
- */
-
 import io.confluent.parallelconsumer.ParallelConsumerOptions;
 import io.confluent.parallelconsumer.ParallelEoSStreamProcessor;
 import io.confluent.parallelconsumer.integrationTests.utils.KafkaClientUtils;

--- a/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/RebalanceTest.java
+++ b/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/RebalanceTest.java
@@ -1,3 +1,7 @@
+
+/*-
+ * Copyright (C) 2020-2023 Confluent, Inc.
+ */
 package io.confluent.parallelconsumer.integrationTests;
 
 /*-


### PR DESCRIPTION
Fix synchronisation logic between transactional producer commit and partition revocation commit

* Fixes https://github.com/confluentinc/parallel-consumer/issues/637

### Checklist

- [X] Documentation (if applicable)
- [X] Changelog