### PR TITLE
[Memory Leak] - remove the retrydue date in compare operation in the ShardManager, leading to memory leak, w…

### DIFF
--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/state/ShardManager.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/state/ShardManager.java
@@ -78,13 +78,13 @@ public class ShardManager<K, V> {
      */
     @Getter(AccessLevel.PACKAGE) // visible for testing
     private final Comparator<WorkContainer<?, ?>> retryQueueWorkContainerComparator = Comparator
-            .comparing((WorkContainer<?, ?> workContainer) -> workContainer.getRetryDueAt())
-            .thenComparing(workContainer -> {
+            //.comparing((WorkContainer<?, ?> workContainer) -> workContainer.getRetryDueAt())
+    		.comparing((WorkContainer<?, ?> workContainer) -> workContainer.offset())        
+    		.thenComparing(workContainer -> {
                 // TopicPartition does not implement comparable
                 TopicPartition tp = workContainer.getTopicPartition();
                 return tp.topic() + tp.partition();
-            })
-            .thenComparing(WorkContainer::offset);
+            });
 
     /**
      * Read optimised view of {@link WorkContainer}s that need retrying.


### PR DESCRIPTION
This fix, remove the retrydate in the comparator on the retryQueue.
 
When the message is retried, a new date is settedup on failures, and this duplicate the entry in the retryQueue, leading to memory leaks in entries in the queue.

Even if the current comparator sort the queue using it, it is not currently used is practice in the development


### Checklist

- [X ] Documentation (if applicable)
- [ ] Changelog