### PR TITLE
Make PC message buffer size configurable

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -22,6 +22,10 @@ endif::[]
 * fix: Fix synchronisation logic for transactional producer commit affecting non-transactional usage (#665), resolves (#637)
 * fix: Fix for race condition in partition state clean/dirty tracking (#666), resolves (#664)
 
+=== Improvements
+
+* feature: Make PC message buffer size configurable - two new configuration options for controlling buffer size added (#682)
+
 == 0.5.2.7
 
 === Fixes

--- a/README.adoc
+++ b/README.adoc
@@ -309,7 +309,6 @@ As an illustrative example of relative performance, given:
 ** numberOfThreads = 16
 
 .Comparative performance of order modes and key spaces
-
 [cols="1,1,1,3",options="header"]
 |===
 |Ordering
@@ -730,9 +729,14 @@ Note that in PARTITION ordered mode it may be necessary to tune Consumer fetch b
 
 As default buffer size is calculated as `maxConcurrency * batchSize * loadFactor` - it can be quite small in PARTITION order by default (as concurrency is typically low) and processing threads can be starved if incoming message rate is higher than processing rate as small buffer gets filled with messages from only subset of subscribed partitions before back-pressure kicks in.
 
-It may be not enough to just increase the buffer size - so tuning of underlying Kafka Consumer `max.partition.fetch.bytes` is recommended - with rough target to return X number of messages so that ParallelConsumer buffer is 2 * partitionCount * X. That way back pressure will only kick in after Consumer done at least 2 polls from each subscribed partition.
+It may be not enough to just increase the buffer size - so tuning of underlying Kafka Consumer `max.partition.fetch.bytes` is recommended - there are two approaches that could be used to tune it - depending on data distribution.
+
+One - have a large enough buffer to smooth out spikes in specific partitions - this approach may still lead to thread starvation in cases when processing is relatively slow and some partitions have no data for periods of time or data is consistently unevenly partitioned - as buffer will get filled and will take some time to resume polling, but is acceptable when data flow is more or less consistent.
+Rough target to return X number of messages so that ParallelConsumer buffer is 2 * partitionCount * X. That way back pressure will only kick in after Consumer done at least 2 polls from each subscribed partition.
 
 For example - with 5 subscribed partitions and 1KB message size - can use 500KB `max.partition.fetch.bytes` to get a cap of maximum 500 records per partition fetch - so using guide above set `messageBufferSize` to 5000 ( 2*5*500 ) as a starting point - and tune from there depending on processing speed - but keeping similar (or higher) ratio of `messageBufferSize` to maximum number of records fetched per partition.
+
+Two - have a small buffer and small `max.partition.fetch.bytes` - for scenarios when processing is slow and there is no goal to maximize message polling throughput - setting those values low - will allow to drain buffer faster in cases where data flow is inconsistent and some partitions may have no data for periods of time. As a rough starting point buffer can be set to same 2 * fetch per partition * number of partitions - but partition fetch size set to a low value - for example for messages that take 1 second to process - 5-10 messages per fetch per partition would give reasonable buffer drain time and not poll excessively.
 
 Note:: Kafka Consumer option `max.poll.records` does not change number of records actually fetched by Kafka Consumer - so it is not really useful for this tuning.
 
@@ -1032,17 +1036,14 @@ For a code example, see the <<streams-usage-code>> section.
 
 .Example usage with Kafka Streams
 image::https://lucid.app/publicSegments/view/43f2740c-2a7f-4b7f-909e-434a5bbe3fbf/image.png[Kafka Streams Usage,align="center"]
-
 [[mertics]]
 == Metrics
 
-Metrics collection subsystem is implemented using Micrometer.
-This allows for flexible configuration of target metrics backend to be used.
-See below on example of how to configure MeterRegistry for Parallel Consumer to use for metrics collection.
+Metrics collection subsystem is implemented using Micrometer. This allows for flexible configuration of target metrics backend to be used. See below on example of how to configure MeterRegistry for Parallel Consumer to use for metrics collection.
 
 === Meters
-
 Following meters are defined by Parallel Consumer - grouped by Subsystem
+
 
 ==== Partition Manager
 
@@ -1158,8 +1159,7 @@ Total number of records failed to be processed
 
 Counter `pc.slow.records{subsystem=workmanager, topic="topicName", partition="partitionNumber"}`
 
-Total number of records that spent more than the configured time threshold in the waiting queue.
-This setting defaults to 10 seconds
+Total number of records that spent more than the configured time threshold in the waiting queue. This setting defaults to 10 seconds
 
 ==== Broker Poller
 
@@ -1202,7 +1202,6 @@ Distribution Summary `pc.payload.ratio.used{subsystem=offsetencoder}`
 Ratio between offset metadata payload size and offsets encoded
 
 === Example Metrics setup steps
-
 Meter registry that metrics should be bound has to be set using Parallel Consumer Options along with any common tags that identify the PC instance.
 In addition, if desired - Kafka Consumer, Producer can be bound to the registry as well as general JVM metric, logging system and other common binders.
 
@@ -1232,16 +1231,14 @@ Following example illustrates setup of Parallel Consumer with Meter Registry and
         return eosStreamProcessor;
     }
 ----
-
 <1> - Meter Registry is set through ParallelConsumerOptions.builder(), if not specified - will default to CompositeMeterRegistry - which is No-op.
 <2> - Optional - common tags can be specified through same builder - they will be added to all Parallel Consumer meters
-<3> - Optional - instance tag value can be specified - it has to be unique to ensure meter uniqueness in cases when multiple parallel consumer instances are recording metrics to the same meter registry.
-If instance tag is not specified - unique UUID value will be generated and used.
-Tag is created with tag key 'pcinstance'.
+<3> - Optional - instance tag value can be specified - it has to be unique to ensure meter uniqueness in cases when multiple parallel consumer instances are recording metrics to the same meter registry. If instance tag is not specified - unique UUID value will be generated and used. Tag is created with tag key 'pcinstance'.
 <4> - Optional - Kafka Consumer Micrometer metrics object created for Kafka Consumer that is later used for Parallel Consumer.
 <5> - Optional - Kafka Consumer Micrometer metrics are bound to Meter Registry.
 
 NOTE:: any additional binders / metrics need to be cleaned up appropriately - for example the Kafka Consumer Metrics registered above - need to be closed using `kafkaClientMetrics.close()` after calling shutting down Parallel Consumer as Parallel Consumer will close Kafka Consumer on shutdown.
+
 
 [[roadmap]]
 == Roadmap
@@ -1466,6 +1463,7 @@ The offset map is compressed in parallel using two different compression techniq
 The sizes of the compressed maps are then compared, and the smallest chosen for serialization.
 If both serialised formats are significantly large, they are then both compressed using `zstd` compression, and if that results in a smaller serialization then the compressed form is used instead.
 
+
 ==== Storage Notes
 
 * Runtime data model creates list of incomplete offsets
@@ -1544,6 +1542,10 @@ endif::[]
 * fix: Fix synchronisation logic for transactional producer commit affecting non-transactional usage (#665), resolves (#637)
 * fix: Fix for race condition in partition state clean/dirty tracking (#666), resolves (#664)
 
+=== Improvements
+
+* feature: Make PC message buffer size configurable - two new configuration options for controlling buffer size added (#682)
+
 == 0.5.2.7
 
 === Fixes
@@ -1559,7 +1561,6 @@ endif::[]
 * Refactored metrics implementation to not use singleton - improves meter separation, allows correct metrics subsystem operation when multiple parallel consumer instances are running in same java process (#630), fixes (#617) improves on (#627)
 
 == 0.5.2.6
-
 === Improvements
 
 * feature: Micrometer metrics (#594)
@@ -1629,11 +1630,13 @@ endif::[]
 ** build(deps-dev): bump Confluent Platform Kafka Broker to 7.2.2 (#421)
 ** build(deps): Upgrade to AK 3.3.0 (#309)
 
+
 === Fixes
 
 * fixes #419: NoSuchElementException during race condition in PartitionState (#422)
 * Fixes #412: ClassCastException with retryDelayProvider (#417)
 * fixes ShardManager retryQueue ordering and set issues due to poor Comparator implementation (#423)
+
 
 == v0.5.2.2
 

--- a/README.adoc
+++ b/README.adoc
@@ -309,6 +309,7 @@ As an illustrative example of relative performance, given:
 ** numberOfThreads = 16
 
 .Comparative performance of order modes and key spaces
+
 [cols="1,1,1,3",options="header"]
 |===
 |Ordering
@@ -725,6 +726,20 @@ This option is most like normal operation, except if the consumer is assigned mo
 .Partition ordered concurrent processing of messages
 image::https://lucid.app/publicSegments/view/30ad8632-e8fe-4e05-8afd-a2b6b3bab309/image.png[align="center"]
 
+Note that in PARTITION ordered mode it may be necessary to tune Consumer fetch bytes per partition and ParallelConsumer message buffer size in `ParallelConsumerOptions` (either through specifying relatively high `initialLoadFactor` and `maximumLoadFactor` or explicitly setting `messageBufferSize`).
+
+As default buffer size is calculated as `maxConcurrency * batchSize * loadFactor` - it can be quite small in PARTITION order by default (as concurrency is typically low) and processing threads can be starved if incoming message rate is higher than processing rate as small buffer gets filled with messages from only subset of subscribed partitions before back-pressure kicks in.
+
+It may be not enough to just increase the buffer size - so tuning of underlying Kafka Consumer `max.partition.fetch.bytes` is recommended - with rough target to return X number of messages so that ParallelConsumer buffer is 2 * partitionCount * X. That way back pressure will only kick in after Consumer done at least 2 polls from each subscribed partition.
+
+For example - with 5 subscribed partitions and 1KB message size - can use 500KB `max.partition.fetch.bytes` to get a cap of maximum 500 records per partition fetch - so using guide above set `messageBufferSize` to 5000 ( 2*5*500 ) as a starting point - and tune from there depending on processing speed - but keeping similar (or higher) ratio of `messageBufferSize` to maximum number of records fetched per partition.
+
+Note:: Kafka Consumer option `max.poll.records` does not change number of records actually fetched by Kafka Consumer - so it is not really useful for this tuning.
+
+
+
+Refer to `PartitionOrderProcessingTest` integration tests for example scenario.
+
 === Ordered by Key
 
 Most similar to ordered by partition, this mode ensures process ordering by *key* (per partition).
@@ -1017,14 +1032,17 @@ For a code example, see the <<streams-usage-code>> section.
 
 .Example usage with Kafka Streams
 image::https://lucid.app/publicSegments/view/43f2740c-2a7f-4b7f-909e-434a5bbe3fbf/image.png[Kafka Streams Usage,align="center"]
+
 [[mertics]]
 == Metrics
 
-Metrics collection subsystem is implemented using Micrometer. This allows for flexible configuration of target metrics backend to be used. See below on example of how to configure MeterRegistry for Parallel Consumer to use for metrics collection.
+Metrics collection subsystem is implemented using Micrometer.
+This allows for flexible configuration of target metrics backend to be used.
+See below on example of how to configure MeterRegistry for Parallel Consumer to use for metrics collection.
 
 === Meters
-Following meters are defined by Parallel Consumer - grouped by Subsystem
 
+Following meters are defined by Parallel Consumer - grouped by Subsystem
 
 ==== Partition Manager
 
@@ -1140,7 +1158,8 @@ Total number of records failed to be processed
 
 Counter `pc.slow.records{subsystem=workmanager, topic="topicName", partition="partitionNumber"}`
 
-Total number of records that spent more than the configured time threshold in the waiting queue. This setting defaults to 10 seconds
+Total number of records that spent more than the configured time threshold in the waiting queue.
+This setting defaults to 10 seconds
 
 ==== Broker Poller
 
@@ -1183,6 +1202,7 @@ Distribution Summary `pc.payload.ratio.used{subsystem=offsetencoder}`
 Ratio between offset metadata payload size and offsets encoded
 
 === Example Metrics setup steps
+
 Meter registry that metrics should be bound has to be set using Parallel Consumer Options along with any common tags that identify the PC instance.
 In addition, if desired - Kafka Consumer, Producer can be bound to the registry as well as general JVM metric, logging system and other common binders.
 
@@ -1212,14 +1232,16 @@ Following example illustrates setup of Parallel Consumer with Meter Registry and
         return eosStreamProcessor;
     }
 ----
+
 <1> - Meter Registry is set through ParallelConsumerOptions.builder(), if not specified - will default to CompositeMeterRegistry - which is No-op.
 <2> - Optional - common tags can be specified through same builder - they will be added to all Parallel Consumer meters
-<3> - Optional - instance tag value can be specified - it has to be unique to ensure meter uniqueness in cases when multiple parallel consumer instances are recording metrics to the same meter registry. If instance tag is not specified - unique UUID value will be generated and used. Tag is created with tag key 'pcinstance'.
+<3> - Optional - instance tag value can be specified - it has to be unique to ensure meter uniqueness in cases when multiple parallel consumer instances are recording metrics to the same meter registry.
+If instance tag is not specified - unique UUID value will be generated and used.
+Tag is created with tag key 'pcinstance'.
 <4> - Optional - Kafka Consumer Micrometer metrics object created for Kafka Consumer that is later used for Parallel Consumer.
 <5> - Optional - Kafka Consumer Micrometer metrics are bound to Meter Registry.
 
 NOTE:: any additional binders / metrics need to be cleaned up appropriately - for example the Kafka Consumer Metrics registered above - need to be closed using `kafkaClientMetrics.close()` after calling shutting down Parallel Consumer as Parallel Consumer will close Kafka Consumer on shutdown.
-
 
 [[roadmap]]
 == Roadmap
@@ -1444,7 +1466,6 @@ The offset map is compressed in parallel using two different compression techniq
 The sizes of the compressed maps are then compared, and the smallest chosen for serialization.
 If both serialised formats are significantly large, they are then both compressed using `zstd` compression, and if that results in a smaller serialization then the compressed form is used instead.
 
-
 ==== Storage Notes
 
 * Runtime data model creates list of incomplete offsets
@@ -1538,6 +1559,7 @@ endif::[]
 * Refactored metrics implementation to not use singleton - improves meter separation, allows correct metrics subsystem operation when multiple parallel consumer instances are running in same java process (#630), fixes (#617) improves on (#627)
 
 == 0.5.2.6
+
 === Improvements
 
 * feature: Micrometer metrics (#594)
@@ -1607,13 +1629,11 @@ endif::[]
 ** build(deps-dev): bump Confluent Platform Kafka Broker to 7.2.2 (#421)
 ** build(deps): Upgrade to AK 3.3.0 (#309)
 
-
 === Fixes
 
 * fixes #419: NoSuchElementException during race condition in PartitionState (#422)
 * Fixes #412: ClassCastException with retryDelayProvider (#417)
 * fixes ShardManager retryQueue ordering and set issues due to poor Comparator implementation (#423)
-
 
 == v0.5.2.2
 

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/ParallelConsumerOptions.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/ParallelConsumerOptions.java
@@ -5,11 +5,11 @@ package io.confluent.parallelconsumer;
  */
 
 import io.confluent.parallelconsumer.internal.AbstractParallelEoSStreamProcessor;
+import io.confluent.parallelconsumer.internal.DynamicLoadFactor;
 import io.confluent.parallelconsumer.metrics.PCMetricsDef;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
-import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
@@ -21,13 +21,11 @@ import org.apache.kafka.common.annotation.InterfaceStability;
 
 import java.time.Duration;
 import java.util.Objects;
-import java.util.UUID;
 import java.util.function.Function;
 
 import static io.confluent.csid.utils.StringUtils.msg;
 import static io.confluent.parallelconsumer.ParallelConsumerOptions.CommitMode.PERIODIC_TRANSACTIONAL_PRODUCER;
 import static java.time.Duration.ofMillis;
-import static java.util.Collections.emptyList;
 
 /**
  * The options for the {@link AbstractParallelEoSStreamProcessor} system.
@@ -507,4 +505,34 @@ public class ParallelConsumerOptions<K, V> {
      */
     @Builder.Default
     public final Duration drainTimeout = Duration.ofSeconds(30);
+
+    /**
+     * Message buffer size - overrides use of dynamic load factor to set specific fixed size of message buffer. Useful
+     * when using low concurrency modes - like partition based ordering to get a better mix of messages in the buffer.
+     * As the buffer is shared across multiple partitions - with small buffer it is easy to starve processing threads as
+     * single Consumer poll would will the buffer from single (or low number) of partitions. Setting this value would
+     * effectively set low and high bound of dynamic load factor to a fixed value so that
+     * {@link #getTargetAmountOfRecordsInFlight * loadingFactor} is equal to this size.
+     */
+    public final int messageBufferSize;
+
+    /**
+     * Initial load factor - overrides default starting load factor
+     * {@link io.confluent.parallelconsumer.internal.DynamicLoadFactor#DEFAULT_INITIAL_LOADING_FACTOR}
+     * <p>
+     * Ignored if {@link #messageBufferSize} is specified as dynamic load factor system is set to static load factor to
+     * match requested buffer size.
+     */
+    @Builder.Default
+    public final int initialLoadFactor = DynamicLoadFactor.DEFAULT_INITIAL_LOADING_FACTOR;
+
+    /**
+     * Initial load factor - overrides default maximum load factor
+     * {@link io.confluent.parallelconsumer.internal.DynamicLoadFactor#DEFAULT_MAX_LOADING_FACTOR}
+     * <p>
+     * Ignored if {@link #messageBufferSize} is specified as dynamic load factor system is set to static load factor to
+     * match requested buffer size.
+     */
+    @Builder.Default
+    public final int maximumLoadFactor = DynamicLoadFactor.DEFAULT_MAX_LOADING_FACTOR;
 }

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/ParallelConsumerOptions.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/ParallelConsumerOptions.java
@@ -1,7 +1,7 @@
 package io.confluent.parallelconsumer;
 
 /*-
- * Copyright (C) 2020-2023 Confluent, Inc.
+ * Copyright (C) 2020-2024 Confluent, Inc.
  */
 
 import io.confluent.parallelconsumer.internal.AbstractParallelEoSStreamProcessor;

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/internal/DynamicLoadFactor.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/internal/DynamicLoadFactor.java
@@ -1,7 +1,7 @@
 package io.confluent.parallelconsumer.internal;
 
 /*-
- * Copyright (C) 2020-2022 Confluent, Inc.
+ * Copyright (C) 2020-2024 Confluent, Inc.
  */
 
 import lombok.Getter;

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/internal/DynamicLoadFactor.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/internal/DynamicLoadFactor.java
@@ -14,8 +14,8 @@ import java.time.Instant;
  * Controls a loading factor. Is used to ensure enough messages in multiples of our target concurrency are queued ready
  * for processing.
  * <p>
- * Ensures that increases in loading factor aren't performed a) too soon after the last increase ({@link
- * #isNotCoolingDown()})  and b) too soon after starting the system ({@link #isWarmUpPeriodOver()}).
+ * Ensures that increases in loading factor aren't performed a) too soon after the last increase
+ * ({@link #isNotCoolingDown()})  and b) too soon after starting the system ({@link #isWarmUpPeriodOver()}).
  */
 // todo make so can be fractional like 50% - this is because some systems need a fractional factor, like 1.1 or 1.2 rather than 2
 @Slf4j
@@ -33,7 +33,8 @@ public class DynamicLoadFactor {
      * <p>
      * Starts off as 2, so there's a good guarantee that we start off with enough data queued up.
      */
-    private static final int DEFAULT_INITIAL_LOADING_FACTOR = 2;
+    public static final int DEFAULT_INITIAL_LOADING_FACTOR = 2;
+    public static final int DEFAULT_MAX_LOADING_FACTOR = 100;
 
     private final long startTimeMs = System.currentTimeMillis();
 
@@ -62,12 +63,17 @@ public class DynamicLoadFactor {
      * finishes, theres at least one more entry for it in the queue.
      */
     @Getter
-    private final int maxFactor = 100;
+    private int maxFactor;
 
     @Getter
-    private int currentFactor = DEFAULT_INITIAL_LOADING_FACTOR;
+    private int currentFactor;
     private long lastSteppedFactor = currentFactor;
     private Instant lastStepTime = Instant.MIN;
+
+    public DynamicLoadFactor(int initial, int maximum) {
+        this.currentFactor = initial;
+        this.maxFactor = maximum;
+    }
 
     /**
      * Try to increase the loading factor

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/internal/PCModule.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/internal/PCModule.java
@@ -1,7 +1,7 @@
 package io.confluent.parallelconsumer.internal;
 
 /*-
- * Copyright (C) 2020-2023 Confluent, Inc.
+ * Copyright (C) 2020-2024 Confluent, Inc.
  */
 
 import io.confluent.csid.utils.TimeUtils;

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/internal/PCModule.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/internal/PCModule.java
@@ -89,9 +89,12 @@ public class PCModule<K, V> {
         return parallelEoSStreamProcessor;
     }
 
-    final DynamicLoadFactor dynamicLoadFactor = new DynamicLoadFactor();
+    private DynamicLoadFactor dynamicLoadFactor;
 
     protected DynamicLoadFactor dynamicExtraLoadFactor() {
+        if (dynamicLoadFactor == null) {
+            dynamicLoadFactor = initDynamicLoadFactor();
+        }
         return dynamicLoadFactor;
     }
 
@@ -115,5 +118,14 @@ public class PCModule<K, V> {
             pcMetrics = new PCMetrics(options().getMeterRegistry(), optionsInstance.getMetricsTags(), optionsInstance.getPcInstanceTag());
         }
         return pcMetrics;
+    }
+
+    private DynamicLoadFactor initDynamicLoadFactor() {
+        if (options().getMessageBufferSize() > 0) {
+            int staticLoadFactor = (options().getMessageBufferSize() / options().getTargetAmountOfRecordsInFlight()) + (options().getMessageBufferSize() % options().getTargetAmountOfRecordsInFlight() == 0 ? 0 : 1);
+            return new DynamicLoadFactor(staticLoadFactor, staticLoadFactor);
+        } else {
+            return new DynamicLoadFactor(options().initialLoadFactor, options().maximumLoadFactor);
+        }
     }
 }

--- a/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/PartitionOrderProcessingTest.java
+++ b/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/PartitionOrderProcessingTest.java
@@ -1,0 +1,144 @@
+
+/*-
+ * Copyright (C) 2020-2023 Confluent, Inc.
+ */
+package io.confluent.parallelconsumer.integrationTests;
+
+import io.confluent.csid.utils.ThreadUtils;
+import io.confluent.parallelconsumer.ParallelConsumerOptions;
+import io.confluent.parallelconsumer.ParallelEoSStreamProcessor;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import pl.tlinkowski.unij.api.UniSets;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+import java.util.stream.IntStream;
+
+import static io.confluent.parallelconsumer.ParallelConsumerOptions.ProcessingOrder.PARTITION;
+import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
+
+/**
+ * Tests around what should happen when rebalancing occurs
+ *
+ * @author Antony Stubbs
+ */
+@Slf4j
+class PartitionOrderProcessingTest extends BrokerIntegrationTest<String, String> {
+
+    Consumer<String, String> consumer;
+
+    ParallelEoSStreamProcessor<String, String> pc;
+
+    {
+        super.numPartitions = 5;
+    }
+
+    // todo refactor move up
+    @BeforeEach
+    void setup() {
+        setupTopic();
+        consumer = getKcu().createNewConsumer(true, consumerProps());
+    }
+
+    @AfterEach
+    void cleanup() {
+        pc.close();
+    }
+
+    private ParallelEoSStreamProcessor<String, String> setupPC() {
+        return setupPC(null);
+    }
+
+    private ParallelEoSStreamProcessor<String, String> setupPC(Function<ParallelConsumerOptions.ParallelConsumerOptionsBuilder<String, String>, ParallelConsumerOptions.ParallelConsumerOptionsBuilder<String, String>> optionsCustomizer) {
+        ParallelConsumerOptions.ParallelConsumerOptionsBuilder<String, String> optionsBuilder =
+                ParallelConsumerOptions.<String, String>builder()
+                        .consumer(consumer)
+                        .ordering(PARTITION)
+                        .maxConcurrency(5);
+        if (optionsCustomizer != null) {
+            optionsBuilder = optionsCustomizer.apply(optionsBuilder);
+        }
+
+        return new ParallelEoSStreamProcessor<>(optionsBuilder.build());
+    }
+
+    /**
+     * Check that all partitions are processed in parallel and not starved when Consumer options for max partition fetch
+     * size and ParallelConsumer buffer size are tuned. Increasing ParallelConsumer buffer size improves parallel
+     * processing load over the {@link #allPartitionsAreNotProcessedInParallel()} scenario due to having enough buffer
+     * to fit 10 x polls so allows underlying Consumer to fetch from each partition at least 2 times before
+     * back-pressure control pauses polling.
+     */
+    @SneakyThrows
+    @Test
+    void allPartitionsAreProcessedInParallel() {
+        var numberOfRecordsToProduce = 10000L;
+        Map<Integer, AtomicInteger> partitionCounts = new HashMap<>();
+        IntStream.range(0, 5).forEach(part -> partitionCounts.put(part, new AtomicInteger(0)));
+        pc = setupPC(options -> options.messageBufferSize(5000)); // Increasing message buffer to 10 * max partition fetch - to make sure mix of data from all partitions is available for processing
+        pc.subscribe(UniSets.of(topic));
+
+        //
+        getKcu().produceMessages(topic, numberOfRecordsToProduce);
+
+        // consume all the messages
+        pc.poll(recordContexts -> {
+            partitionCounts.get(recordContexts.getSingleConsumerRecord().partition()).getAndIncrement();
+            ThreadUtils.sleepQuietly(10); // introduce a bit of processing delay - to make sure polling backpressure kicks in.
+        });
+        await().until(() -> partitionCounts.values().stream().mapToInt(AtomicInteger::get).sum() > 500); // wait until we process some messages to get the counts in.
+        Assertions.assertTrue(partitionCounts.values().stream().allMatch(v -> v.get() > 0), "Expect all partitions to have some messages processed, actual partitionCounts:" + partitionCounts);
+
+    }
+
+    /**
+     * Negative test of the {@link #allPartitionsAreProcessedInParallel} confirming that without tuning buffer size and
+     * max partition fetch - processing threads are easily starved in Partition ordering mode.
+     * <p>
+     * This is due to default buffer size is small (max concurrency (5) * batchSize(1) * loadFactor (2 to 100) - gives
+     * buffer of 10 to 500 max.
+     * <p>
+     * With reduced partition fetch size of 50KB and ~100 byte messages - we poll 500 messages per partition. But even
+     * reducing partition fetch size still starves our processing threads as buffer is so small and we have pre-loaded
+     * topics with data to simulate higher incoming rate than processing rate.
+     */
+    @SneakyThrows
+    @Test
+    void allPartitionsAreNotProcessedInParallel() {
+        var numberOfRecordsToProduce = 10000L;
+        Map<Integer, AtomicInteger> partitionCounts = new HashMap<>();
+        IntStream.range(0, 5).forEach(part -> partitionCounts.put(part, new AtomicInteger(0)));
+        pc = setupPC();
+        pc.subscribe(UniSets.of(topic));
+
+        //
+        getKcu().produceMessages(topic, numberOfRecordsToProduce);
+
+        // consume all the messages
+        pc.poll(recordContexts -> {
+            partitionCounts.get(recordContexts.getSingleConsumerRecord().partition()).getAndIncrement();
+            ThreadUtils.sleepQuietly(10); // introduce a bit of processing delay - to make sure polling backpressure kicks in.
+        });
+        await().until(() -> partitionCounts.values().stream().mapToInt(AtomicInteger::get).sum() > 500); // wait until we process some messages to get the counts in.
+        Assertions.assertFalse(partitionCounts.values().stream().allMatch(v -> v.get() > 0), "Expect some processing thread starving and not all partition counts to have some messages processed, actual partitionCounts:" + partitionCounts);
+    }
+
+    //Tune consumer for smaller message polls both per partition and max poll records.
+    private Properties consumerProps() {
+        Properties props = new Properties();
+        props.put(ConsumerConfig.MAX_PARTITION_FETCH_BYTES_CONFIG, 500 * 100); //500 * ~100 byte message
+        props.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 500); //default
+        return props;
+    }
+
+}

--- a/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/PartitionOrderProcessingTest.java
+++ b/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/PartitionOrderProcessingTest.java
@@ -1,8 +1,8 @@
+package io.confluent.parallelconsumer.integrationTests;
 
 /*-
- * Copyright (C) 2020-2023 Confluent, Inc.
+ * Copyright (C) 2020-2024 Confluent, Inc.
  */
-package io.confluent.parallelconsumer.integrationTests;
 
 import io.confluent.csid.utils.ThreadUtils;
 import io.confluent.parallelconsumer.ParallelConsumerOptions;

--- a/parallel-consumer-core/src/test/java/io/confluent/parallelconsumer/internal/LimitedDynamicExtraLoadFactor.java
+++ b/parallel-consumer-core/src/test/java/io/confluent/parallelconsumer/internal/LimitedDynamicExtraLoadFactor.java
@@ -1,7 +1,7 @@
 package io.confluent.parallelconsumer.internal;
 
 /*-
- * Copyright (C) 2020-2023 Confluent, Inc.
+ * Copyright (C) 2020-2024 Confluent, Inc.
  */
 
 public class LimitedDynamicExtraLoadFactor extends DynamicLoadFactor {

--- a/parallel-consumer-core/src/test/java/io/confluent/parallelconsumer/internal/LimitedDynamicExtraLoadFactor.java
+++ b/parallel-consumer-core/src/test/java/io/confluent/parallelconsumer/internal/LimitedDynamicExtraLoadFactor.java
@@ -5,13 +5,7 @@ package io.confluent.parallelconsumer.internal;
  */
 
 public class LimitedDynamicExtraLoadFactor extends DynamicLoadFactor {
-    @Override
-    public int getMaxFactor() {
-        return 2;
-    }
-
-    @Override
-    public int getCurrentFactor() {
-        return 2;
+    public LimitedDynamicExtraLoadFactor() {
+        super(2, 2);
     }
 }

--- a/src/docs/README_TEMPLATE.adoc
+++ b/src/docs/README_TEMPLATE.adoc
@@ -624,6 +624,25 @@ This option is most like normal operation, except if the consumer is assigned mo
 .Partition ordered concurrent processing of messages
 image::https://lucid.app/publicSegments/view/30ad8632-e8fe-4e05-8afd-a2b6b3bab309/image.png[align="center"]
 
+Note that in PARTITION ordered mode it may be necessary to tune Consumer fetch bytes per partition and ParallelConsumer message buffer size in `ParallelConsumerOptions` (either through specifying relatively high `initialLoadFactor` and `maximumLoadFactor` or explicitly setting `messageBufferSize`).
+
+As default buffer size is calculated as `maxConcurrency * batchSize * loadFactor` - it can be quite small in PARTITION order by default (as concurrency is typically low) and processing threads can be starved if incoming message rate is higher than processing rate as small buffer gets filled with messages from only subset of subscribed partitions before back-pressure kicks in.
+
+It may be not enough to just increase the buffer size - so tuning of underlying Kafka Consumer `max.partition.fetch.bytes` is recommended - there are two approaches that could be used to tune it - depending on data distribution.
+
+One - have a large enough buffer to smooth out spikes in specific partitions - this approach may still lead to thread starvation in cases when processing is relatively slow and some partitions have no data for periods of time or data is consistently unevenly partitioned - as buffer will get filled and will take some time to resume polling, but is acceptable when data flow is more or less consistent.
+Rough target to return X number of messages so that ParallelConsumer buffer is 2 * partitionCount * X. That way back pressure will only kick in after Consumer done at least 2 polls from each subscribed partition.
+
+For example - with 5 subscribed partitions and 1KB message size - can use 500KB `max.partition.fetch.bytes` to get a cap of maximum 500 records per partition fetch - so using guide above set `messageBufferSize` to 5000 ( 2*5*500 ) as a starting point - and tune from there depending on processing speed - but keeping similar (or higher) ratio of `messageBufferSize` to maximum number of records fetched per partition.
+
+Two - have a small buffer and small `max.partition.fetch.bytes` - for scenarios when processing is slow and there is no goal to maximize message polling throughput - setting those values low - will allow to drain buffer faster in cases where data flow is inconsistent and some partitions may have no data for periods of time. As a rough starting point buffer can be set to same 2 * fetch per partition * number of partitions - but partition fetch size set to a low value - for example for messages that take 1 second to process - 5-10 messages per fetch per partition would give reasonable buffer drain time and not poll excessively.
+
+Note:: Kafka Consumer option `max.poll.records` does not change number of records actually fetched by Kafka Consumer - so it is not really useful for this tuning.
+
+
+
+Refer to `PartitionOrderProcessingTest` integration tests for example scenario.
+
 === Ordered by Key
 
 Most similar to ordered by partition, this mode ensures process ordering by *key* (per partition).


### PR DESCRIPTION
Make PC message buffer size configurable.
Two configuration options added - specifying message buffer size (which will calculate loading factor and set loading factor to static value) and configurable initial and max loading factors.
* messageBufferSize - takes precedence if specified over load factor options - sets buffer size to approximately specified value by setting load factor to static value calculated as `ceiling ( messageBufferSize / maxConcurrency*batchSize) `
* initialLoadFactor - (default 2) - overrides starting load factor value
* maximumLoadFactor - (default 100) - overrides maximum load factor value

Readme updated to add consideration to tune fetch and buffer size in Partition ordering mode as buffer size can be small by default leading to uneven load per partition and starving processing threads.
Test added to illustrate starved threads scenario and tuning of config to prevent it.

### Checklist

- [X] Documentation (if applicable)
- [x] Changelog