### PR TITLE
use https for repositories

### DIFF
--- a/parallel-consumer-core/pom.xml
+++ b/parallel-consumer-core/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2020-2023 Confluent, Inc.
+    Copyright (C) 2020-2024 Confluent, Inc.
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/parallel-consumer-examples/parallel-consumer-example-core/pom.xml
+++ b/parallel-consumer-examples/parallel-consumer-example-core/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2020-2023 Confluent, Inc.
+    Copyright (C) 2020-2024 Confluent, Inc.
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -42,7 +42,7 @@
         <repository>
             <name>Confluent</name>
             <id>confluent</id>
-            <url>http://packages.confluent.io/maven/</url>
+            <url>https://packages.confluent.io/maven/</url>
         </repository>
         <!-- end::exampleRepo[] -->
     </repositories>

--- a/parallel-consumer-examples/parallel-consumer-example-metrics/pom.xml
+++ b/parallel-consumer-examples/parallel-consumer-example-metrics/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2020-2023 Confluent, Inc.
+    Copyright (C) 2020-2024 Confluent, Inc.
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -67,7 +67,7 @@
         <repository>
             <name>Confluent</name>
             <id>confluent</id>
-            <url>http://packages.confluent.io/maven/</url>
+            <url>https://packages.confluent.io/maven/</url>
         </repository>
         <!-- end::exampleRepo[] -->
     </repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -13,12 +13,12 @@
     <version>0.5.2.8-SNAPSHOT</version>
     <description>Parallel Apache Kafka client wrapper with client side queueing, a simpler consumer/producer API with key concurrency and extendable non-blocking IO processing.
     </description>
-    <url>http://confluent.io</url>
+    <url>https://confluent.io</url>
     <inceptionYear>2020</inceptionYear>
 
     <organization>
         <name>Confluent, Inc.</name>
-        <url>http://confluent.io</url>
+        <url>https://confluent.io</url>
     </organization>
 
     <licenses>
@@ -44,9 +44,9 @@
             <id>antony@confluent.io</id>
             <name>Antony Stubbs</name>
             <email>antony@confluent.io</email>
-            <url>http://confluent.io</url>
+            <url>https://confluent.io</url>
             <organization>Confluent</organization>
-            <organizationUrl>http://confluent.io</organizationUrl>
+            <organizationUrl>https://confluent.io</organizationUrl>
             <timezone>Europe/London</timezone>
         </developer>
     </developers>


### PR DESCRIPTION
Http scheme is used in couple of example sub-module POM files for repository location - updated to HTTPS.
See #675

- [X] Changelog