### PR TITLE
Fix the example code for skipping records to work properly

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -823,7 +823,7 @@ Implementing a https://github.com/confluentinc/parallel-consumer/issues/196[max 
 
         pc.poll(context -> {
             var consumerRecord = context.getSingleRecord().getConsumerRecord();
-            Long retryCount = retriesCount.computeIfAbsent(consumerRecord, ignore -> 0L);
+            Long retryCount = retriesCount.compute(consumerRecord, (key, oldValue) -> oldValue == null ? 0L : oldValue + 1);
             if (retryCount < maxRetries) {
                 processRecord(consumerRecord);
                 // no exception, so completed - remove from map

--- a/parallel-consumer-examples/parallel-consumer-example-core/src/main/java/io/confluent/parallelconsumer/examples/core/CoreApp.java
+++ b/parallel-consumer-examples/parallel-consumer-example-core/src/main/java/io/confluent/parallelconsumer/examples/core/CoreApp.java
@@ -143,7 +143,7 @@ public class CoreApp {
 
         pc.poll(context -> {
             var consumerRecord = context.getSingleRecord().getConsumerRecord();
-            Long retryCount = retriesCount.computeIfAbsent(consumerRecord, ignore -> 0L);
+            Long retryCount = retriesCount.compute(consumerRecord, (key, oldValue) -> oldValue == null ? 0L : oldValue + 1);
             if (retryCount < maxRetries) {
                 processRecord(consumerRecord);
                 // no exception, so completed - remove from map


### PR DESCRIPTION
Fixed the example code for skipping records to work properly. Previously, the example code did not work correctly because retriesCount was constantly 0.

### Checklist

- [x] Documentation (if applicable)
- [x] Changelog