### PR TITLE
GH-725: RecordContext should provide access to lastFailureReason

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -18,6 +18,7 @@ endif::[]
 
 === Improvements
 * improvement: add multiple caches for accelerating available container count calculation （#667）
+* improvement: RecordContext now exposes lastFailureReason (#725)
 
 
 == 0.5.2.8

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/RecordContext.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/RecordContext.java
@@ -71,5 +71,10 @@ public class RecordContext<K, V> {
     public Optional<Instant> getSucceededAt() {
         return workContainer.getSucceededAt();
     }
+
+    /**
+     * @return if the record has failed, returns the last failure reason
+     */
+    public Optional<Throwable> getLastFailureReason() { return workContainer.getLastFailureReason(); }
 }
 


### PR DESCRIPTION
Exposes `lastFailureReason` from `Recordcontext`
