### PR TITLE
fix: Support for PCRetriableException in ReactorProcessor (#733)

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -16,7 +16,12 @@ endif::[]
 
 == 0.5.2.9
 
+=== Fixes
+
+* fix: Support for PCRetriableException in ReactorProcessor (#733)
+
 === Improvements
+
 * improvement: add multiple caches for accelerating available container count calculation （#667）
 * improvement: RecordContext now exposes lastFailureReason (#725)
 
@@ -48,6 +53,7 @@ endif::[]
 * Refactored metrics implementation to not use singleton - improves meter separation, allows correct metrics subsystem operation when multiple parallel consumer instances are running in same java process (#630), fixes (#617) improves on (#627)
 
 == 0.5.2.6
+
 === Improvements
 
 * feature: Micrometer metrics (#594)
@@ -117,13 +123,11 @@ endif::[]
 ** build(deps-dev): bump Confluent Platform Kafka Broker to 7.2.2 (#421)
 ** build(deps): Upgrade to AK 3.3.0 (#309)
 
-
 === Fixes
 
 * fixes #419: NoSuchElementException during race condition in PartitionState (#422)
 * Fixes #412: ClassCastException with retryDelayProvider (#417)
 * fixes ShardManager retryQueue ordering and set issues due to poor Comparator implementation (#423)
-
 
 == v0.5.2.2
 

--- a/README.adoc
+++ b/README.adoc
@@ -1536,7 +1536,12 @@ endif::[]
 
 == 0.5.2.9
 
+=== Fixes
+
+* fix: Support for PCRetriableException in ReactorProcessor (#733)
+
 === Improvements
+
 * improvement: add multiple caches for accelerating available container count calculation （#667）
 * improvement: RecordContext now exposes lastFailureReason (#725)
 
@@ -1568,6 +1573,7 @@ endif::[]
 * Refactored metrics implementation to not use singleton - improves meter separation, allows correct metrics subsystem operation when multiple parallel consumer instances are running in same java process (#630), fixes (#617) improves on (#627)
 
 == 0.5.2.6
+
 === Improvements
 
 * feature: Micrometer metrics (#594)
@@ -1637,13 +1643,11 @@ endif::[]
 ** build(deps-dev): bump Confluent Platform Kafka Broker to 7.2.2 (#421)
 ** build(deps): Upgrade to AK 3.3.0 (#309)
 
-
 === Fixes
 
 * fixes #419: NoSuchElementException during race condition in PartitionState (#422)
 * Fixes #412: ClassCastException with retryDelayProvider (#417)
 * fixes ShardManager retryQueue ordering and set issues due to poor Comparator implementation (#423)
-
 
 == v0.5.2.2
 

--- a/parallel-consumer-reactor/src/main/java/io/confluent/parallelconsumer/reactor/ReactorProcessor.java
+++ b/parallel-consumer-reactor/src/main/java/io/confluent/parallelconsumer/reactor/ReactorProcessor.java
@@ -4,6 +4,7 @@ package io.confluent.parallelconsumer.reactor;
  * Copyright (C) 2020-2022 Confluent, Inc.
  */
 
+import io.confluent.parallelconsumer.PCRetriableException;
 import io.confluent.parallelconsumer.ParallelConsumerOptions;
 import io.confluent.parallelconsumer.PollContext;
 import io.confluent.parallelconsumer.PollContextInternal;
@@ -102,26 +103,10 @@ public class ReactorProcessor<K, V> extends ExternalEngine<K, V> {
                     // it will run in the controller thread, unless user themselves uses either publishOn or successful
                     // subscribeOn
                     .publishOn(getScheduler())
-                    .doOnNext(signal -> {
-                        log.trace("doOnNext {}", signal);
-                    })
-                    .doOnComplete(() -> {
-                        log.debug("Reactor success (doOnComplete)");
-                        pollContext.streamWorkContainers().forEach(wc -> {
-                            wc.onUserFunctionSuccess();
-                            addToMailbox(pollContext, wc);
-                        });
-                    })
-                    .doOnError(throwable -> {
-                        log.error("Reactor fail signal", throwable);
-                        pollContext.streamWorkContainers().forEach(wc -> {
-                            wc.onUserFunctionFailure(throwable);
-                            addToMailbox(pollContext, wc);
-                        });
-                    })
+                    .doOnNext(signal -> log.trace("doOnNext {}", signal))
                     // cause users Publisher to run a thread pool, if it hasn't already - this is a crucial magical part
                     .subscribeOn(getScheduler())
-                    .subscribe();
+                    .subscribe(ignore -> onComplete(pollContext), throwable -> onError(pollContext, throwable));
 
             log.trace("asyncPoll - user function finished ok.");
             return UniLists.of(flux);
@@ -130,6 +115,26 @@ public class ReactorProcessor<K, V> extends ExternalEngine<K, V> {
         //
         Consumer<Object> voidCallBack = (ignore) -> log.trace("Void callback applied.");
         supervisorLoop(wrappedUserFunc, voidCallBack);
+    }
+
+    private void onComplete(PollContextInternal<K, V> pollContext) {
+        log.debug("Reactor success");
+        pollContext.streamWorkContainers().forEach(wc -> {
+            wc.onUserFunctionSuccess();
+            addToMailbox(pollContext, wc);
+        });
+    }
+
+    private void onError(PollContextInternal<K, V> pollContext, Throwable throwable) {
+        if (throwable instanceof PCRetriableException) {
+            log.debug("Reactor fail signal", throwable);
+        } else {
+            log.error("Reactor fail signal", throwable);
+        }
+        pollContext.streamWorkContainers().forEach(wc -> {
+            wc.onUserFunctionFailure(throwable);
+            addToMailbox(pollContext, wc);
+        });
     }
 
     private Scheduler getScheduler() {


### PR DESCRIPTION
* Support for PCRetriableException in ReactorProcessor.
* Error handling moved to subscribe param to avoid onErrorDropped.

### Checklist

- [ ] Documentation (if applicable)
- [x] Changelog