### PR TITLE
Enable semaphore as part of migrating builds from jenkins to semaphoreCI

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -9,4 +9,4 @@ github:
     enable: true
     repo_name: confluentinc/parallel-consumer
 semaphore:
-    enable: false
+    enable: true


### PR DESCRIPTION
Enable semaphore as part of migrating builds from jenkins to semaphoreCI
