### PR TITLE
Fix/public ci job

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -27,6 +27,7 @@ global_job_config:
       value: "-Dmaven.repo.local=.m2"
   prologue:
     commands:
+      - cache clear
       - sem-version java 17
       - checkout
       - git fetch --unshallow
@@ -38,7 +39,8 @@ blocks:
       jobs:
         - name: Build and Test
           commands:
-            - ./mvnw --batch-mode -q -Pci -U clean install
+            - ./mvnw --batch-mode -q -Pci -U clean install -DskipTests
+            - ./mvnw --batch-mode -Pci verify
       epilogue:
         always:
           commands:

--- a/parallel-consumer-core/pom.xml
+++ b/parallel-consumer-core/pom.xml
@@ -125,7 +125,7 @@
                 <artifactId>truth-generator-maven-plugin</artifactId>
                 <version>${truth-generator-maven-plugin.version}</version>
                 <configuration>
-                    <cleanTargetDir>true</cleanTargetDir>
+                    <cleanTargetDir>false</cleanTargetDir>
                     <useHas>false</useHas>
                     <useGetterForLegacyClasses>true</useGetterForLegacyClasses>
                     <releaseTarget>8</releaseTarget>

--- a/parallel-consumer-vertx/pom.xml
+++ b/parallel-consumer-vertx/pom.xml
@@ -17,7 +17,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <properties>
-        <vertx.version>4.5.1</vertx.version>
+        <vertx.version>4.5.7</vertx.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -971,6 +971,10 @@
             <url>https://packages.confluent.io/maven/</url>
         </repository>
         <repository>
+            <id>central</id>
+            <url>https://repo1.maven.org/maven2/</url>
+        </repository>
+        <repository>
             <id>jitpack.io</id>
             <url>https://jitpack.io</url>
         </repository>
@@ -983,6 +987,10 @@
         </repository>
     </repositories>
     <pluginRepositories>
+        <pluginRepository>
+            <id>central</id>
+            <url>https://repo1.maven.org/maven2/</url>
+        </pluginRepository>
         <pluginRepository>
             <id>astubbs-truth-generator</id>
             <url>https://packagecloud.io/astubbs/truth-generator/maven2</url>


### PR DESCRIPTION
Changes to semaphore pipeline and POMs to enable public semaphore CI jobs to run successfully.
Notably project dependencies and build are done as first step - ignoring tests, and then tests are run as a second step.
Minor - bump to vertx version.

### Checklist

- [ ] Documentation (if applicable)
- [ ] Changelog