### PR TITLE
Fix redundant rebalance callback in `LongPollingMockConsumer` for Kafka >= 3.6

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -21,11 +21,16 @@ endif::[]
 * fix: Support for PCRetriableException in ReactorProcessor (#733)
 * fix: NullPointerException on partitions revoked (#757)
 * fix: remove lingeringOnCommitWouldBeBeneficial and unused imports (#732)
+* fix: Fix redundant rebalance callback in LongPollingMockConsumer for Kafka >= 3.6 (#765)
 
 === Improvements
 
 * improvement: add multiple caches for accelerating available container count calculation （#667）
 * improvement: RecordContext now exposes lastFailureReason (#725)
+
+=== Dependencies
+
+* build(deps): Bump Kafka to 3.6.2
 
 == 0.5.2.8
 

--- a/README.adoc
+++ b/README.adoc
@@ -1541,11 +1541,16 @@ endif::[]
 * fix: Support for PCRetriableException in ReactorProcessor (#733)
 * fix: NullPointerException on partitions revoked (#757)
 * fix: remove lingeringOnCommitWouldBeBeneficial and unused imports (#732)
+* fix: Fix redundant rebalance callback in LongPollingMockConsumer for Kafka >= 3.6 (#765)
 
 === Improvements
 
 * improvement: add multiple caches for accelerating available container count calculation （#667）
 * improvement: RecordContext now exposes lastFailureReason (#725)
+
+=== Dependencies
+
+* build(deps): Bump Kafka to 3.6.2
 
 == 0.5.2.8
 

--- a/parallel-consumer-core/src/test/java/io/confluent/csid/utils/LongPollingMockConsumer.java
+++ b/parallel-consumer-core/src/test/java/io/confluent/csid/utils/LongPollingMockConsumer.java
@@ -1,7 +1,7 @@
 package io.confluent.csid.utils;
 
 /*-
- * Copyright (C) 2020-2023 Confluent, Inc.
+ * Copyright (C) 2020-2024 Confluent, Inc.
  */
 import io.confluent.parallelconsumer.internal.AbstractParallelEoSStreamProcessor;
 import lombok.Getter;
@@ -188,16 +188,6 @@ public class LongPollingMockConsumer<K, V> extends MockConsumer<K, V> {
     }
 
     @SneakyThrows
-    @Override
-    public synchronized void rebalance(final Collection<TopicPartition> newAssignment) {
-        super.rebalance(newAssignment);
-        ConsumerRebalanceListener rebalanceListeners = getRebalanceListener();
-        if (rebalanceListeners != null) {
-            rebalanceListeners.onPartitionsAssigned(newAssignment);
-        }
-    }
-
-    @SneakyThrows
     public void revoke(final Collection<TopicPartition> newAssignment) {
         ConsumerRebalanceListener rebalanceListeners = getRebalanceListener();
         if (rebalanceListeners != null) {
@@ -205,6 +195,7 @@ public class LongPollingMockConsumer<K, V> extends MockConsumer<K, V> {
         }
     }
 
+    @Override
     @SneakyThrows
     public synchronized void assign(final Collection<TopicPartition> newAssignment) {
         ConsumerRebalanceListener rebalanceListeners = getRebalanceListener();

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
 
         <!-- core -->
         <slf4j.version>2.0.7</slf4j.version>
-        <kafka.version>3.5.0</kafka.version>
+        <kafka.version>3.6.2</kafka.version>
         <version.unij>0.1.3</version.unij>
 
         <!-- tests -->


### PR DESCRIPTION
Rebalance listeners are invoked by `MockConsumer` since Kafka 3.6.0 (https://github.com/apache/kafka/compare/3.5...3.6#diff-0ebcab2d2727abe3f0f1e3a94321b068ef2478911a33861d072a7a2ecbb1cf1f). Doing it manually is no longer necessary.

The redundant listener invocation caused test failures, for example `PCMetricsTest` (see https://github.com/confluentinc/parallel-consumer/pull/762#issuecomment-2108553270).

Refer to https://github.com/confluentinc/parallel-consumer/pull/762#issuecomment-2110677240 for more details.

### Checklist

- [x] Documentation (if applicable)
- [x] Changelog