### PR TITLE
stale containers exclusion and handling improvement

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -26,6 +26,7 @@ endif::[]
 
 === Improvements
 
+* improvement: stale containers exclusion and handling improvement (#779)
 * improvement: add multiple caches for accelerating available container count calculation （#667）
 * improvement: RecordContext now exposes lastFailureReason (#725)
 

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/internal/AbstractParallelEoSStreamProcessor.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/internal/AbstractParallelEoSStreamProcessor.java
@@ -1321,9 +1321,11 @@ public abstract class AbstractParallelEoSStreamProcessor<K, V> implements Parall
         final List<WorkContainer<K, V>> staleWorkContainers = splitContainersMap.getOrDefault(Boolean.TRUE, new ArrayList<>());
         final PollContextInternal<K, V> internalContext = new PollContextInternal<>(staleWorkContainers);
         try {
-            // when epoch's change, we can't remove them from the executor pool queue, so we just have to skip them when we find them
-            log.debug("Pool found work from old generation of assigned work, skipping message as epoch doesn't match current {}", staleWorkContainers);
-            staleWorkContainers.forEach(wc -> addToMailbox(internalContext, wc));
+            if (!staleWorkContainers.isEmpty()) {
+                // when epoch's change, we can't remove them from the executor pool queue, so we just have to skip them when we find them
+                log.debug("Pool found work from old generation of assigned work, skipping message as epoch doesn't match current {}", staleWorkContainers);
+                staleWorkContainers.forEach(wc -> addToMailbox(internalContext, wc));
+            }
         } finally {
             cleanUpContext(internalContext);
         }

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/internal/AbstractParallelEoSStreamProcessor.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/internal/AbstractParallelEoSStreamProcessor.java
@@ -1282,14 +1282,10 @@ public abstract class AbstractParallelEoSStreamProcessor<K, V> implements Parall
         log.trace("Pool received: {}", workContainerBatch);
 
         /*
-         *  Handle stale work from the batch, before creating the internal context for running user function.
+         *  Handle and filter stale work from the batch, before creating the internal context for running user function.
          *  The context created is used by the "wrapped" user function to inject transactional producer synchronization.
          */
-        final boolean containsStaleWork = wm.checkIfWorkIsStale(workContainerBatch);
-
-        final List<WorkContainer<K, V>> activeWorkContainers = containsStaleWork ?
-                handleStaleWork(workContainerBatch)
-                : workContainerBatch;
+        final List<WorkContainer<K, V>> activeWorkContainers = handleStaleWork(workContainerBatch);
 
         final PollContextInternal<K, V> context = new PollContextInternal<>(activeWorkContainers);
 

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/internal/AbstractParallelEoSStreamProcessor.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/internal/AbstractParallelEoSStreamProcessor.java
@@ -122,7 +122,7 @@ public abstract class AbstractParallelEoSStreamProcessor<K, V> implements Parall
 
     // todo make package level
     @Getter(AccessLevel.PUBLIC)
-    protected final WorkManager<K, V> wm;
+    protected WorkManager<K, V> wm;
 
     /**
      * Collection of work waiting to be
@@ -1318,7 +1318,7 @@ public abstract class AbstractParallelEoSStreamProcessor<K, V> implements Parall
     protected List<WorkContainer<K, V>> handleStaleWork(final List<WorkContainer<K, V>> workContainerBatch) {
         Map<Boolean, List<WorkContainer<K, V>>> splitContainersMap = workContainerBatch.stream()
                 .collect(Collectors.groupingBy(wm::checkIfWorkIsStale));
-        final List<WorkContainer<K, V>> staleWorkContainers = splitContainersMap.get(Boolean.TRUE);
+        final List<WorkContainer<K, V>> staleWorkContainers = splitContainersMap.getOrDefault(Boolean.TRUE, new ArrayList<>());
         final PollContextInternal<K, V> internalContext = new PollContextInternal<>(staleWorkContainers);
         try {
             // when epoch's change, we can't remove them from the executor pool queue, so we just have to skip them when we find them
@@ -1328,7 +1328,7 @@ public abstract class AbstractParallelEoSStreamProcessor<K, V> implements Parall
             cleanUpContext(internalContext);
         }
         // return the normal workContainers
-        return splitContainersMap.get(Boolean.FALSE);
+        return splitContainersMap.getOrDefault(Boolean.FALSE, new ArrayList<>());
     }
 
     protected <R> ArrayList<Tuple<ConsumerRecord<K, V>, R>> runUserFunctionInternal(final Function<PollContextInternal<K, V>, List<R>> usersFunction,

--- a/parallel-consumer-core/src/test/java/io/confluent/parallelconsumer/AbstractParallelEoSStreamProcessorConfigurationTest.java
+++ b/parallel-consumer-core/src/test/java/io/confluent/parallelconsumer/AbstractParallelEoSStreamProcessorConfigurationTest.java
@@ -1,7 +1,7 @@
 package io.confluent.parallelconsumer;
 
 /*-
- * Copyright (C) 2020-2023 Confluent, Inc.
+ * Copyright (C) 2020-2024 Confluent, Inc.
  */
 
 import io.confluent.parallelconsumer.internal.PCModule;

--- a/parallel-consumer-core/src/test/java/io/confluent/parallelconsumer/AbstractParallelEoSStreamProcessorConfigurationTest.java
+++ b/parallel-consumer-core/src/test/java/io/confluent/parallelconsumer/AbstractParallelEoSStreamProcessorConfigurationTest.java
@@ -24,6 +24,9 @@ import pl.tlinkowski.unij.api.UniLists;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
 /**
  * Tests to verify the protected and internal methods of
@@ -88,11 +91,15 @@ class AbstractParallelEoSStreamProcessorConfigurationTest {
 
         try (final TestParallelEoSStreamProcessor<String, String> testInstance = new TestParallelEoSStreamProcessor<>(testOptions)) {
             testInstance.setWm(wm);
+            Function<PollContextInternal<String, String>, List<String>> dummyFunction = (contextInternal) -> new ArrayList<>();
+            Consumer<String> callback = (res) -> {
+            };
 
-            List<WorkContainer<String, String>> normalWorkers = testInstance.handleStaleWork(workContainers);
+            testInstance.runUserFunc(dummyFunction, callback, workContainers);
 
-            Assertions.assertEquals(normalWorkers.size(), 1);
-            Assertions.assertEquals(testInstance.getMailBox().size(), 1);
+
+            Assertions.assertEquals(testInstance.getMailBoxSuccessCnt(), 1);
+            Assertions.assertEquals(testInstance.getMailBoxFailedCnt(), 1);
         }
     }
 
@@ -105,11 +112,15 @@ class AbstractParallelEoSStreamProcessorConfigurationTest {
 
         try (final TestParallelEoSStreamProcessor<String, String> testInstance = new TestParallelEoSStreamProcessor<>(testOptions)) {
             testInstance.setWm(wm);
+            Function<PollContextInternal<String, String>, List<String>> dummyFunction = (contextInternal) -> new ArrayList<>();
+            Consumer<String> callback = (res) -> {
+            };
 
-            List<WorkContainer<String, String>> normalWorkers = testInstance.handleStaleWork(workContainers);
+            testInstance.runUserFunc(dummyFunction, callback, workContainers);
 
-            Assertions.assertEquals(normalWorkers.size(), 2);
-            Assertions.assertEquals(testInstance.getMailBox().size(), 0);
+
+            Assertions.assertEquals(testInstance.getMailBoxSuccessCnt(), 2);
+            Assertions.assertEquals(testInstance.getMailBoxFailedCnt(), 0);
         }
     }
 }

--- a/parallel-consumer-core/src/test/java/io/confluent/parallelconsumer/AbstractParallelEoSStreamProcessorConfigurationTest.java
+++ b/parallel-consumer-core/src/test/java/io/confluent/parallelconsumer/AbstractParallelEoSStreamProcessorConfigurationTest.java
@@ -4,12 +4,26 @@ package io.confluent.parallelconsumer;
  * Copyright (C) 2020-2023 Confluent, Inc.
  */
 
+import io.confluent.parallelconsumer.internal.PCModule;
+import io.confluent.parallelconsumer.internal.PCModuleTestEnv;
 import io.confluent.parallelconsumer.internal.TestParallelEoSStreamProcessor;
+import io.confluent.parallelconsumer.offsets.OffsetMapCodecManager;
+import io.confluent.parallelconsumer.state.ModelUtils;
+import io.confluent.parallelconsumer.state.PartitionState;
+import io.confluent.parallelconsumer.state.WorkContainer;
+import io.confluent.parallelconsumer.state.WorkManager;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.clients.consumer.MockConsumer;
+import org.apache.kafka.common.TopicPartition;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import pl.tlinkowski.unij.api.UniLists;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Tests to verify the protected and internal methods of
@@ -20,6 +34,27 @@ import org.junit.jupiter.api.Test;
  */
 @Slf4j
 class AbstractParallelEoSStreamProcessorConfigurationTest {
+    final MockConsumer<String, String> consumer = new MockConsumer<>(OffsetResetStrategy.LATEST);
+    final ParallelConsumerOptions<String, String> testOptions = ParallelConsumerOptions.<String, String>builder()
+            .consumer(consumer)
+            .build();
+
+    ModelUtils mu = new ModelUtils();
+    PartitionState<String, String> state;
+    WorkManager<String, String> wm;
+
+    String topic = "myTopic";
+    int partition = 0;
+
+    TopicPartition tp = new TopicPartition(topic, partition);
+    PCModule module = new PCModuleTestEnv();
+
+    @BeforeEach
+    public void setup() {
+        state = new PartitionState<>(0, mu.getModule(), tp, OffsetMapCodecManager.HighestOffsetAndIncompletes.of());
+        wm = mu.getModule().workManager();
+        wm.onPartitionsAssigned(UniLists.of(tp));
+    }
 
     /**
      * Test that the {@link io.confluent.parallelconsumer.internal.AbstractParallelEoSStreamProcessor#getQueueTargetLoaded}
@@ -41,6 +76,40 @@ class AbstractParallelEoSStreamProcessorConfigurationTest {
             final int actualTargetLoad = testInstance.getTargetLoad();
 
             Assertions.assertEquals(expectedTargetLoad, actualTargetLoad);
+        }
+    }
+
+    @Test
+    void testHandleStaleWorkSplit() {
+        List<WorkContainer<String, String>> workContainers = new ArrayList<>();
+
+        workContainers.add(new WorkContainer<String, String>(0, new ConsumerRecord<>(topic, partition, 0, "test_k", "test_v1"), module));
+        workContainers.add(new WorkContainer<String, String>(1, new ConsumerRecord<>(topic, partition, 1, "test_k", "test_v2"), module));
+
+        try (final TestParallelEoSStreamProcessor<String, String> testInstance = new TestParallelEoSStreamProcessor<>(testOptions)) {
+            testInstance.setWm(wm);
+
+            List<WorkContainer<String, String>> normalWorkers = testInstance.handleStaleWork(workContainers);
+
+            Assertions.assertEquals(normalWorkers.size(), 1);
+            Assertions.assertEquals(testInstance.getMailBox().size(), 1);
+        }
+    }
+
+    @Test
+    void testHandleStaleWorkNoSplit() {
+        List<WorkContainer<String, String>> workContainers = new ArrayList<>();
+
+        workContainers.add(new WorkContainer<String, String>(0, new ConsumerRecord<>(topic, partition, 0, "test_k", "test_v1"), module));
+        workContainers.add(new WorkContainer<String, String>(0, new ConsumerRecord<>(topic, partition, 1, "test_k", "test_v2"), module));
+
+        try (final TestParallelEoSStreamProcessor<String, String> testInstance = new TestParallelEoSStreamProcessor<>(testOptions)) {
+            testInstance.setWm(wm);
+
+            List<WorkContainer<String, String>> normalWorkers = testInstance.handleStaleWork(workContainers);
+
+            Assertions.assertEquals(normalWorkers.size(), 2);
+            Assertions.assertEquals(testInstance.getMailBox().size(), 0);
         }
     }
 }

--- a/parallel-consumer-core/src/test/java/io/confluent/parallelconsumer/internal/TestParallelEoSStreamProcessor.java
+++ b/parallel-consumer-core/src/test/java/io/confluent/parallelconsumer/internal/TestParallelEoSStreamProcessor.java
@@ -5,6 +5,11 @@ package io.confluent.parallelconsumer.internal;
  */
 
 import io.confluent.parallelconsumer.ParallelConsumerOptions;
+import io.confluent.parallelconsumer.state.WorkContainer;
+import io.confluent.parallelconsumer.state.WorkManager;
+
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
 
 /**
  * Provides a set of methods for testing internal and configuration based interfaces of
@@ -16,4 +21,17 @@ public class TestParallelEoSStreamProcessor<K, V> extends AbstractParallelEoSStr
     }
 
     public int getTargetLoad() { return getQueueTargetLoaded(); }
+
+    public List<WorkContainer<K, V>> handleStaleWork(final List<WorkContainer<K, V>> workContainerBatch) {
+        return super.handleStaleWork(workContainerBatch);
+    }
+
+    public void setWm(WorkManager wm) {
+        super.wm = wm;
+    }
+
+    public BlockingQueue getMailBox() {
+        return super.getWorkMailBox();
+    }
+
 }

--- a/parallel-consumer-core/src/test/java/io/confluent/parallelconsumer/internal/TestParallelEoSStreamProcessor.java
+++ b/parallel-consumer-core/src/test/java/io/confluent/parallelconsumer/internal/TestParallelEoSStreamProcessor.java
@@ -1,7 +1,7 @@
 package io.confluent.parallelconsumer.internal;
 
 /*-
- * Copyright (C) 2020-2023 Confluent, Inc.
+ * Copyright (C) 2020-2024 Confluent, Inc.
  */
 
 import io.confluent.parallelconsumer.ParallelConsumerOptions;


### PR DESCRIPTION
Description...
in previous logic we need two passes to get the normal containers and put stale containers into mailbox queue.
But now we only need one pass, therefore when the traffic is huge, there will be performance gain.
### Checklist

- [ ] Documentation (if applicable)
- [x] Changelog