### PR TITLE
change version in changelog / readme for 0.5.3.0 release

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -14,7 +14,7 @@ ifndef::github_name[]
 toc::[]
 endif::[]
 
-== 0.5.2.9
+== 0.5.3.0
 
 === Fixes
 

--- a/README.adoc
+++ b/README.adoc
@@ -1534,7 +1534,7 @@ ifndef::github_name[]
 toc::[]
 endif::[]
 
-== 0.5.2.9
+== 0.5.3.0
 
 === Fixes
 


### PR DESCRIPTION
Change version in changelog / readme for 0.5.3.0 release.
One of main dependencies (Kafka-clients) updated to 3.7 - it has significant changes, therefore releasing as 0.5.3.0 instead of 0.5.2.9.

### Checklist

- [ ] Documentation (if applicable)
- [ ] Changelog