### PR TITLE
Fix: update vault secret and revert release 0.5.3.0 prep commits

### DIFF
--- a/.semaphore/publish_to_maven.yml
+++ b/.semaphore/publish_to_maven.yml
@@ -30,7 +30,7 @@ blocks :
             - checkout
             - git fetch --unshallow
             - . vault-setup
-            - . vault-sem-get-secret gpg/confluent-packaging-private-8B1DA6120C2BF624
+            - . vault-sem-get-secret v1/ci/kv/semaphore2/gpg/confluent-packaging-private-8B1DA6120C2BF624
             - chmod +x .semaphore/initgpg.sh
             - . .semaphore/initgpg.sh
             - ./mvnw --batch-mode clean deploy -Pmaven-central -Pci -Dgpg.passphrase=$PASSPHRASE -DskipTests

--- a/parallel-consumer-core/pom.xml
+++ b/parallel-consumer-core/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>io.confluent.parallelconsumer</groupId>
         <artifactId>parallel-consumer-parent</artifactId>
-        <version>0.5.3.0</version>
+        <version>0.5.2.9-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/parallel-consumer-core/pom.xml
+++ b/parallel-consumer-core/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>io.confluent.parallelconsumer</groupId>
         <artifactId>parallel-consumer-parent</artifactId>
-        <version>0.5.3.1-SNAPSHOT</version>
+        <version>0.5.3.0</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/parallel-consumer-examples/parallel-consumer-example-core/pom.xml
+++ b/parallel-consumer-examples/parallel-consumer-example-core/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>io.confluent.parallelconsumer</groupId>
         <artifactId>parallel-consumer-examples</artifactId>
-        <version>0.5.3.0</version>
+        <version>0.5.2.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>parallel-consumer-example-core</artifactId>

--- a/parallel-consumer-examples/parallel-consumer-example-core/pom.xml
+++ b/parallel-consumer-examples/parallel-consumer-example-core/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>io.confluent.parallelconsumer</groupId>
         <artifactId>parallel-consumer-examples</artifactId>
-        <version>0.5.3.1-SNAPSHOT</version>
+        <version>0.5.3.0</version>
     </parent>
 
     <artifactId>parallel-consumer-example-core</artifactId>

--- a/parallel-consumer-examples/parallel-consumer-example-metrics/pom.xml
+++ b/parallel-consumer-examples/parallel-consumer-example-metrics/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>io.confluent.parallelconsumer</groupId>
         <artifactId>parallel-consumer-examples</artifactId>
-        <version>0.5.3.1-SNAPSHOT</version>
+        <version>0.5.3.0</version>
     </parent>
 
     <artifactId>parallel-consumer-example-metrics</artifactId>

--- a/parallel-consumer-examples/parallel-consumer-example-metrics/pom.xml
+++ b/parallel-consumer-examples/parallel-consumer-example-metrics/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>io.confluent.parallelconsumer</groupId>
         <artifactId>parallel-consumer-examples</artifactId>
-        <version>0.5.3.0</version>
+        <version>0.5.2.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>parallel-consumer-example-metrics</artifactId>

--- a/parallel-consumer-examples/parallel-consumer-example-reactor/pom.xml
+++ b/parallel-consumer-examples/parallel-consumer-example-reactor/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>io.confluent.parallelconsumer</groupId>
         <artifactId>parallel-consumer-examples</artifactId>
-        <version>0.5.3.1-SNAPSHOT</version>
+        <version>0.5.3.0</version>
     </parent>
 
     <artifactId>parallel-consumer-example-reactor</artifactId>

--- a/parallel-consumer-examples/parallel-consumer-example-reactor/pom.xml
+++ b/parallel-consumer-examples/parallel-consumer-example-reactor/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>io.confluent.parallelconsumer</groupId>
         <artifactId>parallel-consumer-examples</artifactId>
-        <version>0.5.3.0</version>
+        <version>0.5.2.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>parallel-consumer-example-reactor</artifactId>

--- a/parallel-consumer-examples/parallel-consumer-example-streams/pom.xml
+++ b/parallel-consumer-examples/parallel-consumer-example-streams/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>io.confluent.parallelconsumer</groupId>
         <artifactId>parallel-consumer-examples</artifactId>
-        <version>0.5.3.1-SNAPSHOT</version>
+        <version>0.5.3.0</version>
     </parent>
 
     <artifactId>parallel-consumer-example-streams</artifactId>

--- a/parallel-consumer-examples/parallel-consumer-example-streams/pom.xml
+++ b/parallel-consumer-examples/parallel-consumer-example-streams/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>io.confluent.parallelconsumer</groupId>
         <artifactId>parallel-consumer-examples</artifactId>
-        <version>0.5.3.0</version>
+        <version>0.5.2.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>parallel-consumer-example-streams</artifactId>

--- a/parallel-consumer-examples/parallel-consumer-example-vertx/pom.xml
+++ b/parallel-consumer-examples/parallel-consumer-example-vertx/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>io.confluent.parallelconsumer</groupId>
         <artifactId>parallel-consumer-examples</artifactId>
-        <version>0.5.3.1-SNAPSHOT</version>
+        <version>0.5.3.0</version>
     </parent>
 
     <artifactId>parallel-consumer-example-vertx</artifactId>

--- a/parallel-consumer-examples/parallel-consumer-example-vertx/pom.xml
+++ b/parallel-consumer-examples/parallel-consumer-example-vertx/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>io.confluent.parallelconsumer</groupId>
         <artifactId>parallel-consumer-examples</artifactId>
-        <version>0.5.3.0</version>
+        <version>0.5.2.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>parallel-consumer-example-vertx</artifactId>

--- a/parallel-consumer-examples/pom.xml
+++ b/parallel-consumer-examples/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <artifactId>parallel-consumer-parent</artifactId>
         <groupId>io.confluent.parallelconsumer</groupId>
-        <version>0.5.3.1-SNAPSHOT</version>
+        <version>0.5.3.0</version>
     </parent>
 
     <artifactId>parallel-consumer-examples</artifactId>

--- a/parallel-consumer-examples/pom.xml
+++ b/parallel-consumer-examples/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <artifactId>parallel-consumer-parent</artifactId>
         <groupId>io.confluent.parallelconsumer</groupId>
-        <version>0.5.3.0</version>
+        <version>0.5.2.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>parallel-consumer-examples</artifactId>

--- a/parallel-consumer-reactor/pom.xml
+++ b/parallel-consumer-reactor/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <artifactId>parallel-consumer-parent</artifactId>
         <groupId>io.confluent.parallelconsumer</groupId>
-        <version>0.5.3.1-SNAPSHOT</version>
+        <version>0.5.3.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/parallel-consumer-reactor/pom.xml
+++ b/parallel-consumer-reactor/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <artifactId>parallel-consumer-parent</artifactId>
         <groupId>io.confluent.parallelconsumer</groupId>
-        <version>0.5.3.0</version>
+        <version>0.5.2.9-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/parallel-consumer-vertx/pom.xml
+++ b/parallel-consumer-vertx/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>io.confluent.parallelconsumer</groupId>
         <artifactId>parallel-consumer-parent</artifactId>
-        <version>0.5.3.0</version>
+        <version>0.5.2.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>parallel-consumer-vertx</artifactId>

--- a/parallel-consumer-vertx/pom.xml
+++ b/parallel-consumer-vertx/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>io.confluent.parallelconsumer</groupId>
         <artifactId>parallel-consumer-parent</artifactId>
-        <version>0.5.3.1-SNAPSHOT</version>
+        <version>0.5.3.0</version>
     </parent>
 
     <artifactId>parallel-consumer-vertx</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <groupId>io.confluent.parallelconsumer</groupId>
     <artifactId>parallel-consumer-parent</artifactId>
     <name>Confluent Parallel Consumer</name>
-    <version>0.5.3.0</version>
+    <version>0.5.2.9-SNAPSHOT</version>
     <description>Parallel Apache Kafka client wrapper with client side queueing, a simpler consumer/producer API with key concurrency and extendable non-blocking IO processing.
     </description>
     <url>https://confluent.io</url>
@@ -55,7 +55,7 @@
         <connection>scm:git:git://github.com:confluentinc/parallel-consumer.git</connection>
         <developerConnection>scm:git:git@github.com:confluentinc/parallel-consumer.git</developerConnection>
         <url>https://github.com/confluentinc/parallel-consumer.git</url>
-        <tag>0.5.3.0</tag>
+        <tag>0.5.2.6</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <groupId>io.confluent.parallelconsumer</groupId>
     <artifactId>parallel-consumer-parent</artifactId>
     <name>Confluent Parallel Consumer</name>
-    <version>0.5.3.1-SNAPSHOT</version>
+    <version>0.5.3.0</version>
     <description>Parallel Apache Kafka client wrapper with client side queueing, a simpler consumer/producer API with key concurrency and extendable non-blocking IO processing.
     </description>
     <url>https://confluent.io</url>
@@ -55,7 +55,7 @@
         <connection>scm:git:git://github.com:confluentinc/parallel-consumer.git</connection>
         <developerConnection>scm:git:git@github.com:confluentinc/parallel-consumer.git</developerConnection>
         <url>https://github.com/confluentinc/parallel-consumer.git</url>
-        <tag>0.5.2.6</tag>
+        <tag>0.5.3.0</tag>
     </scm>
 
     <distributionManagement>


### PR DESCRIPTION
Secret for GPG signing path is not right - needs updated.
Release prep commits reverted to update the secret path and re-run release steps again.

### Checklist

- [ ] Documentation (if applicable)
- [ ] Changelog