### PR TITLE
remove publish auto-promotion

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -54,5 +54,3 @@ after_pipeline:
 promotions :
   - name : Publish to Maven Central
     pipeline_file : publish_to_maven.yml
-    auto_promote :
-      when : "result = 'passed' and tag =~ '.*'"


### PR DESCRIPTION
Publish auto promote triggers on tag rename (soft delete) - disable for now

### Checklist

- [ ] Documentation (if applicable)
- [ ] Changelog