### PR TITLE
switch retryQueue to ConcurrentSkipListSet to avoid ConcurrentModific…

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -14,6 +14,12 @@ ifndef::github_name[]
 toc::[]
 endif::[]
 
+== 0.5.3.1
+
+=== Fixes
+
+* fix: ConcurrentModificationException Happened while high load and draining (#821)
+
 == 0.5.3.0
 
 === Fixes

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/state/ShardManager.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/state/ShardManager.java
@@ -24,6 +24,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.stream.Collectors;
 
 import static io.confluent.parallelconsumer.ParallelConsumerOptions.ProcessingOrder.KEY;
@@ -92,7 +93,7 @@ public class ShardManager<K, V> {
      * Read optimised view of {@link WorkContainer}s that need retrying.
      */
     @Getter(AccessLevel.PACKAGE) // visible for testing
-    private final NavigableSet<WorkContainer<?, ?>> retryQueue = new TreeSet<>(retryQueueWorkContainerComparator);
+    private final NavigableSet<WorkContainer<?, ?>> retryQueue = new ConcurrentSkipListSet<>(retryQueueWorkContainerComparator);
 
     /**
      * Iteration resume point, to ensure fairness (prevent shard starvation) when we can't process messages from every


### PR DESCRIPTION
Description...
fix for issue #821.
Since BrokerPollSystem and ControlLoop will both update / query the `retryQueue`, the legacy `TreeSet` cannot handle different threads access.

### Checklist

- [ ] Documentation (if applicable)
- [x] Changelog