### PR TITLE
fix for message loss for issue 826

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -18,6 +18,7 @@ endif::[]
 
 === Fixes
 
+* fix: message loss on closing or partitions revoked (#826)
 * fix: ConcurrentModificationException Happened while high load and draining (#822) fixes (#821)
 * fix: safely completing doClose() (#818) partially fixes (#809)
 * Improved offset commit retry. Add support for SaslAuthenticationException retry timeout (#819), partially fixes (#809) in Commit_Sync mode

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/state/PartitionState.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/state/PartitionState.java
@@ -240,7 +240,7 @@ public class PartitionState<K, V> {
             return false;
         } else {
             // if within the range of tracked offsets, must have been previously completed, as it's not in the incomplete set
-            return recOffset <= offsetHighestSeen;
+            return recOffset <= offsetHighestSucceeded;
         }
     }
 
@@ -459,7 +459,8 @@ public class PartitionState<K, V> {
          *
          * See #200 for the complete correct solution.
          */
-        long currentOffsetHighestSeen = offsetHighestSeen;
+        // use offsetHighestSucceeded instead of offsetHighestSeen to fix issue #826
+        long currentOffsetHighestSeen = offsetHighestSucceeded;
         Long firstIncompleteOffset = incompleteOffsets.keySet().ceiling(KAFKA_OFFSET_ABSENCE);
         boolean incompleteOffsetsWasEmpty = firstIncompleteOffset == null;
 

--- a/parallel-consumer-core/src/test/java/io/confluent/parallelconsumer/ParallelEoSSStreamProcessorRebalancedTest.java
+++ b/parallel-consumer-core/src/test/java/io/confluent/parallelconsumer/ParallelEoSSStreamProcessorRebalancedTest.java
@@ -17,7 +17,6 @@ import org.junit.jupiter.params.provider.EnumSource;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static com.google.common.truth.Truth.assertThat;
 import static pl.tlinkowski.unij.api.UniLists.of;
 
 @Slf4j
@@ -60,35 +59,6 @@ class ParallelEoSSStreamProcessorRebalancedTest extends ParallelEoSStreamProcess
         addRecordsWithSetKeyForEachPartition();
         countDownLatch.countDown();
         awaitForCommit(4);
-    }
-
-
-    @ParameterizedTest
-    @EnumSource(CommitMode.class)
-    @SneakyThrows
-    public void messageLossWithTimingPartitionRevoke() {
-        // 1. insert one record
-        // 2. before getWorkIfAvailable, the partition revoked
-        // 3. the timing of revoking should be happening right after check isDirty
-        // 4. the incompleteOffsets is cleared since it is overridden by RemovedPartitionState
-        // 5. commit the offset, with empty incompleteOffsets
-        // 6. container is marked as stale and be filtered
-        CommitMode commitMode = CommitMode.PERIODIC_CONSUMER_ASYNCHRONOUS;
-        final CountDownLatch countDownLatch = new CountDownLatch(1);
-        final PCModuleTestEnv pcModuleTestEnv = new PCModuleTestEnv(getBaseOptions(commitMode), countDownLatch);
-        parallelConsumer = new ParallelEoSStreamProcessor<>(getBaseOptions(commitMode), pcModuleTestEnv);
-        parentParallelConsumer = parallelConsumer;
-        parallelConsumer.subscribe(of(INPUT_TOPIC));
-        this.consumerSpy.subscribeWithRebalanceAndAssignment(of(INPUT_TOPIC), 2);
-        attachLoopCounter(parallelConsumer);
-        primeFirstRecord();
-        consumerSpy.revoke(of(new TopicPartition(INPUT_TOPIC, 0)));
-        parallelConsumer.requestCommitAsap();
-        parallelConsumer.poll(context -> {
-            countDownLatch.countDown();
-        });
-
-        assertThat(countDownLatch.getCount()).isEqualTo(1L);
     }
 
     private void addRecordsWithSetKeyForEachPartition() {

--- a/parallel-consumer-core/src/test/java/io/confluent/parallelconsumer/ParallelEoSSStreamProcessorRebalancedTest.java
+++ b/parallel-consumer-core/src/test/java/io/confluent/parallelconsumer/ParallelEoSSStreamProcessorRebalancedTest.java
@@ -69,9 +69,10 @@ class ParallelEoSSStreamProcessorRebalancedTest extends ParallelEoSStreamProcess
     public void messageLossWithTimingPartitionRevoke() {
         // 1. insert one record
         // 2. before getWorkIfAvailable, the partition revoked
-        // 3. the incompleteOffsets is cleared since it is overridden by RemovedPartitionState
-        // 4. commit the offset, with empty incompleteOffsets
-        // 5. container is marked as stale and be filtered
+        // 3. the timing of revoking should be happening right after check isDirty
+        // 4. the incompleteOffsets is cleared since it is overridden by RemovedPartitionState
+        // 5. commit the offset, with empty incompleteOffsets
+        // 6. container is marked as stale and be filtered
         CommitMode commitMode = CommitMode.PERIODIC_CONSUMER_ASYNCHRONOUS;
         final CountDownLatch countDownLatch = new CountDownLatch(1);
         final PCModuleTestEnv pcModuleTestEnv = new PCModuleTestEnv(getBaseOptions(commitMode), countDownLatch);


### PR DESCRIPTION
Description...
fix for #826.
Explanation:
The root cause is that :
1. currently the offset to be committed is according to `offsetHighestSeen `, but this variable is updated as soon as it is polled from kafka and not processed yet.
2. The committer is independent of the message processing since it is periodic committer within `BrokerPollSystem`
3. right before the container is ready to be processed, the partition revoked.
4. And the container is regarded as stale but this is correct behavior but the problem is that the offset is committed, the new consumer will skip this record.

The issue is rare because it has to met with following conditions:
```
1. before the work container is executed (selected ready to be run), the partition revoked (close / rebalancing)
2. there is commit happen, and it is right after the partition revoked
3. the timing of revoking should be happening right after check isDirty 
```

check the doc : https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ConcurrentHashMap.html
```
Retrieval operations (including get) generally do not block, so may overlap with update operations (including put and remove). Retrievals reflect the results of the most recently completed update operations holding upon their onset.
```

Repro log, the miss offset is **329888**

```2024-08-31 00:08:50.784 +09:00 [pc-broker-poll] TRACE i.c.p.i.AbstractParallelEoSStreamProcessor -- Adding EpochAndRecordsMap(recordMap={order.message_loss_repro_test.1-3=EpochAndRecordsMap.RecordsAndEpoch(topicPartition=order.message_loss_repro_test.1-3, epochOfPartitionAtPoll=0, records=[ConsumerRecord(topic = order.message_loss_repro_test.1, partition = 3, leaderEpoch = 4, offset = 329888, LogAppendTime = 1725030530805, serialized key size = 5, serialized value size = 39, headers = RecordHeaders(headers = [RecordHeader(key = x-coupang-publisher-vdc, value = [86, 68, 67, 95, 75, 82]), RecordHeader(key = counect.publish.timestamp, value = [49, 55, 50, 53, 48, 51, 48, 53, 51, 48, 54, 57, 55]), RecordHeader(key = x-coupang-message-queue-vdc, value = [86, 68, 67, 95, 75, 82]), RecordHeader(key = x-coupang-message-lang, value = [101, 110, 95, 85, 83])], isReadOnly = false), key = 46283, value = [B@7678ad84)])}) to mailbox...

2024-08-31 00:08:50.791 +09:00 [pc-control] TRACE i.c.p.state.PartitionState -- Updating highest seen - was: 329887 now: 329888
2024-08-31 00:08:50.831 +09:00 [pc-broker-poll] DEBUG i.c.p.i.AbstractOffsetCommitter -- Will commit offsets for 3 partition(s): {order.message_loss_repro_test.1-5=OffsetAndMetadata{offset=329937, leaderEpoch=null, metadata=''}, order.message_loss_repro_test.1-4=OffsetAndMetadata{offset=333666, leaderEpoch=null, metadata=''}, order.message_loss_repro_test.1-3=OffsetAndMetadata{offset=329889, leaderEpoch=null, metadata=''}}
2024-08-31 00:08:50.831 +09:00 [pc-broker-poll] DEBUG i.c.p.i.AbstractParallelEoSStreamProcessor -- Partitions revoked [order.message_loss_repro_test.1-3, order.message_loss_repro_test.1-4, order.message_loss_repro_test.1-5], state: RUNNING
2024-08-31 00:08:50.832 +09:00 [pc-control] DEBUG i.c.p.state.PartitionState -- Epoch mismatch 0 vs -1 for record WorkContainer(tp:order.message_loss_repro_test.1-3:o:329888:k:46283). Skipping message - it's partition has already assigned to a different consumer.
2024-08-31 00:08:50.832 +09:00 [pc-control] DEBUG i.c.p.state.PartitionState -- Work is in queue with stale epoch or no longer assigned. Skipping.
```
 
```
2024-08-31 00:08:50.784 : consumer receive the message
2024-08-31 00:08:50.791 : update the offset to be commit 329888 (this is wrong logic, which causing the issue)
2024-08-31 00:08:50.831 : offset committed
2024-08-31 00:08:50.831 : partition revoked
2024-08-31 00:08:50.832: while processing the message, since the partition is revoked, 329888 is regarded as stale, is filtered out without processing.
Then message loss happened. Because the offset is committed.
```

### Checklist

- [ ] Documentation (if applicable)
- [x] Changelog