### PR TITLE
Fix retry queue implementation to prevent unbounded growth

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -13,12 +13,17 @@ NOTE:: Dependency version bumps are not listed here.
 ifndef::github_name[]
 toc::[]
 endif::[]
+== 0.5.3.2
+
+=== Fixes
+
+* fix: message loss on closing or partitions revoked (#827) fixes (#826)
+* fix: unbounded retry queue growth preventing polling from being throttled and leading to OOM (#834) fixes (#832, #817)
 
 == 0.5.3.1
 
 === Fixes
 
-* fix: message loss on closing or partitions revoked (#826)
 * fix: ConcurrentModificationException Happened while high load and draining (#822) fixes (#821)
 * fix: safely completing doClose() (#818) partially fixes (#809)
 * Improved offset commit retry. Add support for SaslAuthenticationException retry timeout (#819), partially fixes (#809) in Commit_Sync mode

--- a/README.adoc
+++ b/README.adoc
@@ -1533,12 +1533,17 @@ NOTE:: Dependency version bumps are not listed here.
 ifndef::github_name[]
 toc::[]
 endif::[]
+== 0.5.3.2
+
+=== Fixes
+
+* fix: message loss on closing or partitions revoked (#827) fixes (#826)
+* fix: unbounded retry queue growth preventing polling from being throttled and leading to OOM (#834) fixes (#832, #817)
 
 == 0.5.3.1
 
 === Fixes
 
-* fix: message loss on closing or partitions revoked (#826)
 * fix: ConcurrentModificationException Happened while high load and draining (#822) fixes (#821)
 * fix: safely completing doClose() (#818) partially fixes (#809)
 * Improved offset commit retry. Add support for SaslAuthenticationException retry timeout (#819), partially fixes (#809) in Commit_Sync mode

--- a/README.adoc
+++ b/README.adoc
@@ -1538,6 +1538,7 @@ endif::[]
 
 === Fixes
 
+* fix: message loss on closing or partitions revoked (#826)
 * fix: ConcurrentModificationException Happened while high load and draining (#822) fixes (#821)
 * fix: safely completing doClose() (#818) partially fixes (#809)
 * Improved offset commit retry. Add support for SaslAuthenticationException retry timeout (#819), partially fixes (#809) in Commit_Sync mode

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/state/RetryQueue.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/state/RetryQueue.java
@@ -1,0 +1,304 @@
+package io.confluent.parallelconsumer.state;
+
+/*-
+ * Copyright (C) 2020-2024 Confluent, Inc.
+ */
+
+import io.confluent.parallelconsumer.ParallelConsumer;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import org.apache.kafka.common.utils.CloseableIterator;
+
+import java.time.Instant;
+import java.util.*;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+/**
+ * Custom Sorted Set implementation for the retry queue. Difference from standard Sorted Set is that it allows
+ * uniqueness constraint to be based on different set of fields than sorting logic. Uniqueness is based on Topic,
+ * Partition and Offset of the WorkContainer while sorting is done based on RetryDueAt, Topic, Partition and Offset.
+ * <p>
+ * To enable that - Set is implemented using two Maps - uniqueness map and sorted map - uniqueness map is used to link
+ * the unique keys to sorting keys while sorted map is used to store the sorted elements.
+ * <p>
+ * Implementation is thread safe and uses ReadWriteLock to allow multiple readers or single writer. Due to use of the
+ * locks - it is important to close the Iterator in timely fashion to release the lock and prevent deadlocks.
+ * <p>
+ * Only a subset of Set methods are implemented - add, remove, clear and iterator - as those are only methods used by
+ * the Parallel Consumer code.
+ */
+public class RetryQueue {
+
+    @Getter(AccessLevel.PACKAGE) //visible for testing
+    private final Map<WorkContainerKey, WorkContainerSortKey> unique = new HashMap<>();
+    @Getter(AccessLevel.PACKAGE) //visible for testing
+    private final NavigableMap<WorkContainerSortKey, WorkContainer<?, ?>> sorted;
+
+    @Getter(AccessLevel.PACKAGE) //visible for testing
+    private final Comparator<WorkContainerSortKey> comparator = Comparator
+            .comparing(WorkContainerSortKey::getRetryDueAt)
+            .thenComparing(WorkContainerKey::getTopic)
+            .thenComparing(WorkContainerKey::getPartition)
+            .thenComparing(WorkContainerSortKey::getOffset);
+
+    private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock(true);
+
+    public RetryQueue() {
+        sorted = new TreeMap<>(comparator);
+    }
+
+    /**
+     * Get the size of the set
+     *
+     * @return size of the set
+     */
+    public int size() {
+        return unique.size();
+    }
+
+    /**
+     * Check if the set is empty
+     *
+     * @return true if the set is empty
+     */
+    public boolean isEmpty() {
+        return unique.isEmpty();
+    }
+
+    /**
+     * Check if the set contains a work container - based on Topic, Partition and Offset
+     */
+    public boolean contains(final WorkContainer<?, ?> wc) {
+        lock.readLock().lock();
+        try {
+            return unique.containsKey(WorkContainerKey.of(wc));
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    /**
+     * Clear the set
+     */
+    public void clear() {
+        lock.writeLock().lock();
+        try {
+            unique.clear();
+            sorted.clear();
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    /**
+     * Iterator over the sorted set. Access is guarded by Read lock - so it is really important for it to be closed in
+     * timely fashion to release the lock.
+     *
+     * @return iterator
+     */
+    public RetryQueueIterator iterator() {
+        lock.readLock().lock();
+        return new RetryQueueIterator(lock, sorted.values().iterator());
+    }
+
+    /**
+     * Add a work container to the set. Method follows Set.add() behaviour, returning true if the element was not
+     * already present.
+     *
+     * @param workContainer to add
+     * @return true if the element was not already present
+     */
+    public boolean add(final WorkContainer<?, ?> workContainer) {
+        lock.writeLock().lock();
+        try {
+            WorkContainerKey newKey = WorkContainerKey.of(workContainer);
+            WorkContainerSortKey newSortKey = WorkContainerSortKey.of(workContainer);
+
+            WorkContainerSortKey existing = unique.put(newKey, newSortKey);
+            if (existing != null) {
+                sorted.remove(existing);
+            }
+            sorted.put(newSortKey, workContainer);
+            // interface is set based, so return boolean indicating if element was not present.
+            return existing == null;
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    /**
+     * Remove a work container from the set. Method follows Set.remove() behaviour, returning true if the element was
+     * present.
+     *
+     * @param workContainer
+     * @return
+     */
+    public boolean remove(final WorkContainer<?, ?> workContainer) {
+        lock.writeLock().lock();
+        try {
+            WorkContainerKey newKey = WorkContainerKey.of(workContainer);
+            WorkContainerSortKey existing = unique.remove(newKey);
+            if (existing != null) {
+                sorted.remove(existing);
+            }
+            return existing != null;
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    /**
+     * Remove all specified work containers from the set. Method follows Set.removeAll() behaviour, returning true if
+     * the set was modified.
+     *
+     * @param toRemove collection of work containers to remove
+     * @return true if the set was modified
+     */
+    public <K, V> boolean removeAll(List<WorkContainer<K, V>> toRemove) {
+        if (toRemove == null || unique.isEmpty()) {
+            return false;
+        }
+        lock.writeLock().lock();
+        try {
+            List<WorkContainerKey> keysToRemove = toRemove.stream().map(WorkContainerKey::of).toList();
+            boolean modified = false;
+            for (WorkContainerKey wcKey : keysToRemove) {
+                WorkContainerSortKey existing = unique.remove(wcKey);
+                if (existing != null) {
+                    sorted.remove(existing);
+                    modified = true;
+                }
+            }
+            return modified;
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    public WorkContainer<?, ?> last() {
+        lock.readLock().lock();
+        try {
+            return sorted.isEmpty() ? null : sorted.lastEntry().getValue();
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    public WorkContainer<?, ?> first() {
+        lock.readLock().lock();
+        try {
+            return sorted.isEmpty() ? null : sorted.firstEntry().getValue();
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    /**
+     * Returns a pair of values - current retry queue size and number of work containers that are ready to be retried
+     * Method is combined to provide consistent view of the queue - both values calculated while locked with same read lock
+     * preventing racing updates between two reads.
+     * @return pair of values - current retry queue size and number of work containers that are ready to be retried
+     */
+    public ParallelConsumer.Tuple<Integer, Long> getQueueSizeAndNumberReadyToBeRetried() {
+        lock.readLock().lock();
+        try {
+            return new ParallelConsumer.Tuple<>(sorted.size(), getNumberOfFailedWorkReadyToBeRetried());
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    private long getNumberOfFailedWorkReadyToBeRetried() {
+        long count = 0;
+        //First check if last element is ready to be retried - in that case all before it are ready too
+        if (Optional.ofNullable(sorted.isEmpty() ? null : sorted.lastEntry().getValue()).map(WorkContainer::isDelayPassed).orElse(false)) {
+            return sorted.size();
+        }
+        Iterator<WorkContainer<?, ?>> iterator = sorted.values().iterator();
+        while (iterator.hasNext()) {
+            WorkContainer<?, ?> workContainer = iterator.next();
+            //count all work containers that are ready to be retried but not inflight yet
+            if (workContainer.isDelayPassed()) {
+                count++;
+            } else {
+                // early stop since retryQueue is sorted by retryDueAt
+                break;
+            }
+        }
+        return count;
+    }
+
+
+    @Getter
+    @EqualsAndHashCode
+    static class WorkContainerKey {
+        private final String topic;
+        private final Integer partition;
+        private final Long offset;
+
+        private WorkContainerKey(String topic, Integer partition, Long offset) {
+            this.topic = topic;
+            this.partition = partition;
+            this.offset = offset;
+        }
+
+        static WorkContainerKey of(WorkContainer<?, ?> workContainer) {
+            return new WorkContainerKey(workContainer.getTopicPartition().topic(),
+                    workContainer.getTopicPartition().partition(),
+                    workContainer.getCr().offset());
+        }
+    }
+
+    @Getter
+    @EqualsAndHashCode(callSuper = true)
+    static class WorkContainerSortKey extends WorkContainerKey {
+        private final Instant retryDueAt;
+
+        private WorkContainerSortKey(final String topic, final Integer partition, final Long offset, Instant retryDueAt) {
+            super(topic, partition, offset);
+            this.retryDueAt = retryDueAt;
+        }
+
+        static WorkContainerSortKey of(WorkContainer<?, ?> workContainer) {
+            return new WorkContainerSortKey(workContainer.getTopicPartition().topic(),
+                    workContainer.getTopicPartition().partition(),
+                    workContainer.getCr().offset(),
+                    workContainer.getRetryDueAt());
+        }
+    }
+
+    public static class RetryQueueIterator implements CloseableIterator<WorkContainer<?, ?>> {
+        private final ReentrantReadWriteLock lock;
+        private final Iterator<WorkContainer<?, ?>> wrapped;
+        private boolean closed;
+
+        public RetryQueueIterator(ReentrantReadWriteLock lock, Iterator<WorkContainer<?, ?>> wrapped) {
+            this.lock = lock;
+            this.wrapped = wrapped;
+            this.closed = false;
+        }
+
+        @Override
+        public void close() {
+            lock.readLock().unlock();
+            this.closed = true;
+        }
+
+        @Override
+        public boolean hasNext() {
+            if (closed) {
+                throw new IllegalStateException("RetryQueueIterator is closed");
+            }
+            return wrapped.hasNext();
+        }
+
+        @Override
+        public WorkContainer<?, ?> next() {
+            if (closed) {
+                throw new IllegalStateException("RetryQueueIterator is closed");
+            }
+            return wrapped.next();
+        }
+    }
+}

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/state/RetryQueue.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/state/RetryQueue.java
@@ -13,6 +13,7 @@ import org.apache.kafka.common.utils.CloseableIterator;
 import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.stream.Collectors;
 
 /**
  * Custom Sorted Set implementation for the retry queue. Difference from standard Sorted Set is that it allows
@@ -161,7 +162,7 @@ public class RetryQueue {
         }
         lock.writeLock().lock();
         try {
-            List<WorkContainerKey> keysToRemove = toRemove.stream().map(WorkContainerKey::of).toList();
+            List<WorkContainerKey> keysToRemove = toRemove.stream().map(WorkContainerKey::of).collect(Collectors.toList());
             boolean modified = false;
             for (WorkContainerKey wcKey : keysToRemove) {
                 WorkContainerSortKey existing = unique.remove(wcKey);
@@ -196,8 +197,9 @@ public class RetryQueue {
 
     /**
      * Returns a pair of values - current retry queue size and number of work containers that are ready to be retried
-     * Method is combined to provide consistent view of the queue - both values calculated while locked with same read lock
-     * preventing racing updates between two reads.
+     * Method is combined to provide consistent view of the queue - both values calculated while locked with same read
+     * lock preventing racing updates between two reads.
+     *
      * @return pair of values - current retry queue size and number of work containers that are ready to be retried
      */
     public ParallelConsumer.Tuple<Integer, Long> getQueueSizeAndNumberReadyToBeRetried() {

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/state/WorkManager.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/state/WorkManager.java
@@ -1,7 +1,7 @@
 package io.confluent.parallelconsumer.state;
 
 /*-
- * Copyright (C) 2020-2023 Confluent, Inc.
+ * Copyright (C) 2020-2024 Confluent, Inc.
  */
 
 import io.confluent.parallelconsumer.ParallelConsumerOptions;

--- a/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/RetriesTest.java
+++ b/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/RetriesTest.java
@@ -1,0 +1,104 @@
+
+/*-
+ * Copyright (C) 2020-2024 Confluent, Inc.
+ */
+package io.confluent.parallelconsumer.integrationTests;
+
+/*-
+ * Copyright (C) 2024 Confluent, Inc.
+ */
+
+import io.confluent.csid.utils.ThreadUtils;
+import io.confluent.parallelconsumer.PCRetriableException;
+import io.confluent.parallelconsumer.ParallelConsumerOptions;
+import io.confluent.parallelconsumer.ParallelEoSStreamProcessor;
+import io.confluent.parallelconsumer.integrationTests.utils.KafkaClientUtils;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.RandomUtils;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import pl.tlinkowski.unij.api.UniSets;
+
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static io.confluent.parallelconsumer.ParallelConsumerOptions.ProcessingOrder.KEY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
+import static org.testcontainers.shaded.org.hamcrest.Matchers.equalTo;
+import static org.testcontainers.shaded.org.hamcrest.Matchers.is;
+
+@Slf4j
+public class RetriesTest extends BrokerIntegrationTest<String, String> {
+
+    Consumer<String, String> consumer;
+
+    ParallelConsumerOptions<String, String> pcOpts;
+    ParallelEoSStreamProcessor<String, String> pc;
+
+    @BeforeEach
+    void setUp() {
+        setupTopic();
+        consumer = getKcu().createNewConsumer(KafkaClientUtils.GroupOption.NEW_GROUP);
+
+        pcOpts = ParallelConsumerOptions.<String, String>builder()
+                .consumer(consumer)
+                .ordering(KEY)
+                .maxConcurrency(100)
+                .defaultMessageRetryDelay(Duration.ofMillis(200))
+                .messageBufferSize(10000)
+                .build();
+
+        pc = new ParallelEoSStreamProcessor<>(pcOpts);
+
+        pc.subscribe(UniSets.of(topic));
+    }
+
+    @Test
+    @SneakyThrows
+    void awaitingWorkContainersSizeDoesNotExceedNumberOfFailedContainersInRetryLoop() {
+        String throwExceptionFlag = "throw";
+        var latch = new CountDownLatch(1);
+
+        getKcu().produceMessagesWithThrowHeader(topic, 4000);
+        AtomicInteger count = new AtomicInteger(0);
+        AtomicBoolean throwOnHeader = new AtomicBoolean(true);
+        pc.poll((context) -> {
+            ThreadUtils.sleepQuietly(7); //not multiple of retry delay or vice versa
+            if (throwOnHeader.get()) {
+                if (context.getSingleConsumerRecord().headers().lastHeader(throwExceptionFlag) != null) {
+                    throw new PCRetriableException("THROW_EXCEPTION_FLAG_HAPPENED");
+                }
+            }
+            count.incrementAndGet();
+        });
+        await().atMost(Duration.ofSeconds(10)).pollInterval(Duration.ofMillis(100)).until(count::get, is(equalTo(2000))); //wait for all successful messages to complete
+        AtomicBoolean failed = new AtomicBoolean(false);
+        AtomicBoolean checking = new AtomicBoolean(true);
+        new Thread(() -> {
+            try {
+                while (checking.get()) {
+                    long countAwaiting = pc.getWm().getSm().getNumberOfWorkQueuedInShardsAwaitingSelection();
+                    log.debug("NumberOfWorkQueuedInShardsAwaitingSelection : {}", countAwaiting);
+                    assertThat(countAwaiting).isBetween(0L, 2000L);
+                    ThreadUtils.sleepQuietly(RandomUtils.nextInt(1, 10));
+                }
+            } catch (AssertionError e) {
+                failed.set(true);
+                throw e;
+            } finally {
+                latch.countDown();
+            }
+        }).start();
+        ThreadUtils.sleepQuietly(3000);
+        throwOnHeader.set(false);
+        ThreadUtils.sleepQuietly(2000);
+        checking.set(false);
+        latch.await();
+        assertThat(failed.get()).isFalse();
+    }
+}

--- a/parallel-consumer-core/src/test/java/io/confluent/parallelconsumer/truth/ConsumerSubject.java
+++ b/parallel-consumer-core/src/test/java/io/confluent/parallelconsumer/truth/ConsumerSubject.java
@@ -1,7 +1,7 @@
 package io.confluent.parallelconsumer.truth;
 
 /*-
- * Copyright (C) 2020-2022 Confluent, Inc.
+ * Copyright (C) 2020-2024 Confluent, Inc.
  */
 
 import com.google.common.truth.FailureMetadata;


### PR DESCRIPTION
Fixes #832 #817 
RetryQueue implementation is incorrect due to difference in WorkContainer equals (which is done by topic, partition and offset) and ordering / comparator used for NavigatableSet.
NavigatableSet (or more broadly - standard SortedSet implementations in Java) - use comparator for uniqueness checks instead of equals - and sorting is done taking retryDueAt into account - hence work containers with same topic, partition and offset but differing retryDueAt values are treated as not equal leading to "duplicates" and unbounded retry queue growth on looping retries.
Implementation is rewritten using double Map approach - HashMap for uniqueness checks and TreeMap for sorting.
ReadWrite lock used for access synchronisation - while allowing for concurrent reads.
There is still slight race condition when working out number of shards available for selection as update to work container status in shards and retry queue state is not atomic - but the difference is negligible for determination of whether more work should be allowed / polled for.
Tests added to validate correctness / no unbound growth happening any more.
Implementation of reading retryQueue size and determining number of containers ready for retry is slightly ugly - as it had to be placed inside RetryQueue implementation - so that it can be locked by same read lock to prevent even more raciness.
Ideally the state tracking of available work in shards and retry queue state would be refactored to be done atomically or in synchronised updates - not necessarily using locks / in blocking manner.   

Follow up change planned to include number of containers pending in the work thread queues into work waiting in shards / buffer size computation.

### Checklist

- [ ] Documentation (if applicable)
- [X] Changelog