### PR TITLE
fixes #830: Close PC when InvalidPidMappingException

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -17,6 +17,7 @@ endif::[]
 
 === Fixes
 
+* fix: close parallel consumer on transactional mode when InvalidPidMappingException (#830)
 * fix: include inflight message count in polling backpressure logic (#836)
 * fix: message loss on closing or partitions revoked (#827) fixes (#826)
 * fix: unbounded retry queue growth preventing polling from being throttled and leading to OOM (#834) fixes (#832, #817)

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -13,11 +13,17 @@ NOTE:: Dependency version bumps are not listed here.
 ifndef::github_name[]
 toc::[]
 endif::[]
-== 0.5.3.2
+
+== 0.5.3.3
 
 === Fixes
 
 * fix: close parallel consumer on transactional mode when InvalidPidMappingException (#830)
+
+== 0.5.3.2
+
+=== Fixes
+
 * fix: include inflight message count in polling backpressure logic (#836)
 * fix: message loss on closing or partitions revoked (#827) fixes (#826)
 * fix: unbounded retry queue growth preventing polling from being throttled and leading to OOM (#834) fixes (#832, #817)

--- a/README.adoc
+++ b/README.adoc
@@ -1533,6 +1533,13 @@ NOTE:: Dependency version bumps are not listed here.
 ifndef::github_name[]
 toc::[]
 endif::[]
+
+== 0.5.3.3
+
+=== Fixes
+
+* fix: close parallel consumer on transactional mode when InvalidPidMappingException (#830)
+
 == 0.5.3.2
 
 === Fixes

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/ParallelEoSStreamProcessor.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/ParallelEoSStreamProcessor.java
@@ -1,7 +1,7 @@
 package io.confluent.parallelconsumer;
 
 /*-
- * Copyright (C) 2020-2023 Confluent, Inc.
+ * Copyright (C) 2020-2024 Confluent, Inc.
  */
 
 import io.confluent.csid.utils.TimeUtils;
@@ -13,6 +13,7 @@ import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.errors.InvalidPidMappingException;
 import pl.tlinkowski.unij.api.UniLists;
 
 import java.util.ArrayList;
@@ -132,6 +133,9 @@ public class ParallelEoSStreamProcessor<K, V> extends AbstractParallelEoSStreamP
                 }
                 return null; // return from timer function
             });
+        } catch (InvalidPidMappingException invalidPidMappingException) {
+            log.error("Closing parallel Consumer due to InvalidPidMappingException", invalidPidMappingException);
+            this.closeOnException(invalidPidMappingException);
         } catch (Exception e) {
             throw new InternalRuntimeException("Error while waiting for produce results", e);
         }

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/internal/AbstractParallelEoSStreamProcessor.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/internal/AbstractParallelEoSStreamProcessor.java
@@ -568,6 +568,17 @@ public abstract class AbstractParallelEoSStreamProcessor<K, V> implements Parall
         closeDontDrainFirst();
     }
 
+    /**
+     * Close the system without draining and set failure reason
+     * @param exception
+     *
+     * @see State#DRAINING
+     */
+    public void closeOnException(Exception exception){
+        this.failureReason = exception;
+        closeDontDrainFirst();
+    }
+
     @Override
     public void close(Duration timeout, DrainingMode drainMode) {
         shutdownTimeout = timeout;


### PR DESCRIPTION
Closes #830 

Problem
In transactional mode, when ParallelConsumer encounters an InvalidPidMapping exception, it retries records indefinitely leading to same exception.

Proposed Solution
Parallel Consumer should exit when encoutering InvalidPidMapping. 


### Checklist

- [ ] Documentation (if applicable)
- [x] Changelog