### PR TITLE
Support Kafka-clients 3.9.0

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -19,6 +19,7 @@ endif::[]
 === Fixes
 
 * fix: close parallel consumer on transactional mode when InvalidPidMappingException (#830)
+* fix: support kafka-clients 3.9.0 (#841)
 
 == 0.5.3.2
 

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/internal/AbstractParallelEoSStreamProcessor.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/internal/AbstractParallelEoSStreamProcessor.java
@@ -528,7 +528,9 @@ public abstract class AbstractParallelEoSStreamProcessor<K, V> implements Parall
                     (org.apache.kafka.clients.consumer.Consumer<?, ?>) delegateField.get(kafkaConsumer);
             requireNonNull(delegate, "Consumer delegate must not be null");
 
-            if ("org.apache.kafka.clients.consumer.internals.LegacyKafkaConsumer".equals(delegate.getClass().getName())) {
+            if ("org.apache.kafka.clients.consumer.internals.LegacyKafkaConsumer".equals(delegate.getClass().getName())
+                    // kafka-clients >= 3.9.0
+                    || "org.apache.kafka.clients.consumer.internals.ClassicKafkaConsumer".equals(delegate.getClass().getName())) {
                 final boolean autoCommitEnabled = getAutoCommitEnabledFromCoordinator(delegate.getClass(), delegate);
                 return Optional.of(autoCommitEnabled);
             } else if ("org.apache.kafka.clients.consumer.internals.AsyncKafkaConsumer".equals(delegate.getClass().getName())) {


### PR DESCRIPTION
[KAFKA-17060](https://issues.apache.org/jira/browse/KAFKA-17060) broke the retrieval of autocommit enabled in
AbstractParallelEoSStreamProcessor#getAutoCommitEnabled.

Relates to #840 

### Checklist

- [ ] Documentation (if applicable)
- [x] Changelog