### PR TITLE
Migrate ossrh to maven plugin

### DIFF
--- a/.semaphore/publish_to_maven.yml
+++ b/.semaphore/publish_to_maven.yml
@@ -30,9 +30,9 @@ blocks :
             - . vault-sem-get-secret v1/ci/kv/semaphore2/gpg/confluent-packaging-private-8B1DA6120C2BF624
             - chmod +x .semaphore/initgpg.sh
             - . .semaphore/initgpg.sh
-            - export SONATYPE_SERVER_ID=ossrh
-            - export SONATYPE_OSSRH_USER=$(vault kv get --field=user_token_username v1/ci/kv/sonatype/confluent)
-            - export SONATYPE_OSSRH_PASSWORD=$(vault kv get --field=user_token_password v1/ci/kv/sonatype/confluent)
+            - export SONATYPE_SERVER_ID=central
+            - export CENTRAL_TOKEN_USERNAME=$(vault kv get --field=user_token_username v1/ci/kv/sonatype/confluent)
+            - export CENTRAL_TOKEN_PASSWORD=$(vault kv get --field=user_token_password v1/ci/kv/sonatype/confluent)
             - export SETTINGS_XML_PATH="$HOME/.m2/settings.xml"
             - python .semaphore/update_maven_settings.py # Update maven settings with Sonatype credentials
             - ./mvnw --batch-mode clean deploy -Pmaven-central -Pci -Dgpg.passphrase=$PASSPHRASE -DskipTests

--- a/.semaphore/update_maven_settings.py
+++ b/.semaphore/update_maven_settings.py
@@ -4,8 +4,8 @@ import xml.dom.minidom
 
 
 def get_environment_variables():
-    username = os.getenv("SONATYPE_OSSRH_USER")
-    password = os.getenv("SONATYPE_OSSRH_PASSWORD")
+    username = os.getenv("CENTRAL_TOKEN_USERNAME")
+    password = os.getenv("CENTRAL_TOKEN_PASSWORD")
     server_id = os.getenv("SONATYPE_SERVER_ID")
     settings_xml_path = os.getenv("SETTINGS_XML_PATH")
 

--- a/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/BrokerIntegrationTest.java
+++ b/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/BrokerIntegrationTest.java
@@ -1,5 +1,9 @@
 
 /*-
+ * Copyright (C) 2020-2025 Confluent, Inc.
+ */
+
+/*-
  * Copyright (C) 2020-2023 Confluent, Inc.
  */
 package io.confluent.parallelconsumer.integrationTests;

--- a/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/BrokerIntegrationTest.java
+++ b/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/BrokerIntegrationTest.java
@@ -52,7 +52,7 @@ public abstract class BrokerIntegrationTest<K, V> {
     public static KafkaContainer kafkaContainer = createKafkaContainer(null);
 
     public static KafkaContainer createKafkaContainer(String logSegmentSize) {
-        KafkaContainer base = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.3.0"))
+        KafkaContainer base = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.6.0"))
                 .withEnv("KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR", "1") //transaction.state.log.replication.factor
                 .withEnv("KAFKA_TRANSACTION_STATE_LOG_MIN_ISR", "1") //transaction.state.log.min.isr
                 .withEnv("KAFKA_TRANSACTION_STATE_LOG_NUM_PARTITIONS", "1") //transaction.state.log.num.partitions

--- a/pom.xml
+++ b/pom.xml
@@ -58,17 +58,7 @@
         <tag>0.5.3.2</tag>
     </scm>
 
-    <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-        <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-    </distributionManagement>
-
+    
     <properties>
         <source.version>17</source.version>
         <release.target>8</release.target>
@@ -229,12 +219,7 @@
                     <value>true</value>
                 </property>
             </activation>
-            <distributionManagement>
-                <snapshotRepository>
-                    <id>ossrh</id>
-                    <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-                </snapshotRepository>
-            </distributionManagement>
+            
             <build>
                 <plugins>
                     <plugin>
@@ -252,14 +237,14 @@
                         </executions>
                     </plugin>
                     <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.7.0</version>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.8.0</version>
                         <extensions>true</extensions>
                         <configuration>
-                            <serverId>ossrh</serverId>
-                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                            <publishingServerId>central</publishingServerId>
+                            <autoPublish>true</autoPublish>
+                            <waitUntil>published</waitUntil>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
This pull request updates the Maven publishing workflow to use Sonatype Central instead of OSSRH, aligning credentials and plugin configuration across the CI pipeline and build files. The changes ensure that publishing uses the new Sonatype Central infrastructure and credentials, and replace the legacy Nexus Staging plugin with the new Central Publishing plugin.

**CI/CD Pipeline and Credential Updates:**

* Updated environment variable names and values in `.semaphore/publish_to_maven.yml` to use `CENTRAL_TOKEN_USERNAME`, `CENTRAL_TOKEN_PASSWORD`, and `central` instead of OSSRH-related variables and server ID.
* Modified `.semaphore/update_maven_settings.py` to retrieve Sonatype Central credentials from the new environment variables.

**Maven Build and Publishing Configuration:**

* Removed the `distributionManagement` section referencing OSSRH from `pom.xml`, eliminating legacy publishing configuration. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L61-L70) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L232-R222)
* Replaced the `nexus-staging-maven-plugin` with the new `central-publishing-maven-plugin`, updating plugin group, artifact, version, and configuration to match Sonatype Central requirements.

