### PR TITLE
Fix broken prepare:release on CI/CD

### DIFF
--- a/parallel-consumer-core/pom.xml
+++ b/parallel-consumer-core/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>io.confluent.parallelconsumer</groupId>
         <artifactId>parallel-consumer-parent</artifactId>
-        <version>0.5.3.2</version>
+        <version>0.5.3.3-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/parallel-consumer-examples/parallel-consumer-example-core/pom.xml
+++ b/parallel-consumer-examples/parallel-consumer-example-core/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>io.confluent.parallelconsumer</groupId>
         <artifactId>parallel-consumer-examples</artifactId>
-        <version>0.5.3.2</version>
+        <version>0.5.3.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>parallel-consumer-example-core</artifactId>

--- a/parallel-consumer-examples/parallel-consumer-example-metrics/pom.xml
+++ b/parallel-consumer-examples/parallel-consumer-example-metrics/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>io.confluent.parallelconsumer</groupId>
         <artifactId>parallel-consumer-examples</artifactId>
-        <version>0.5.3.2</version>
+        <version>0.5.3.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>parallel-consumer-example-metrics</artifactId>

--- a/parallel-consumer-examples/parallel-consumer-example-reactor/pom.xml
+++ b/parallel-consumer-examples/parallel-consumer-example-reactor/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>io.confluent.parallelconsumer</groupId>
         <artifactId>parallel-consumer-examples</artifactId>
-        <version>0.5.3.2</version>
+        <version>0.5.3.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>parallel-consumer-example-reactor</artifactId>

--- a/parallel-consumer-examples/parallel-consumer-example-streams/pom.xml
+++ b/parallel-consumer-examples/parallel-consumer-example-streams/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>io.confluent.parallelconsumer</groupId>
         <artifactId>parallel-consumer-examples</artifactId>
-        <version>0.5.3.2</version>
+        <version>0.5.3.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>parallel-consumer-example-streams</artifactId>

--- a/parallel-consumer-examples/parallel-consumer-example-vertx/pom.xml
+++ b/parallel-consumer-examples/parallel-consumer-example-vertx/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>io.confluent.parallelconsumer</groupId>
         <artifactId>parallel-consumer-examples</artifactId>
-        <version>0.5.3.2</version>
+        <version>0.5.3.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>parallel-consumer-example-vertx</artifactId>

--- a/parallel-consumer-examples/pom.xml
+++ b/parallel-consumer-examples/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <artifactId>parallel-consumer-parent</artifactId>
         <groupId>io.confluent.parallelconsumer</groupId>
-        <version>0.5.3.2</version>
+        <version>0.5.3.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>parallel-consumer-examples</artifactId>

--- a/parallel-consumer-reactor/pom.xml
+++ b/parallel-consumer-reactor/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <artifactId>parallel-consumer-parent</artifactId>
         <groupId>io.confluent.parallelconsumer</groupId>
-        <version>0.5.3.2</version>
+        <version>0.5.3.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/parallel-consumer-vertx/pom.xml
+++ b/parallel-consumer-vertx/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>io.confluent.parallelconsumer</groupId>
         <artifactId>parallel-consumer-parent</artifactId>
-        <version>0.5.3.2</version>
+        <version>0.5.3.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>parallel-consumer-vertx</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <groupId>io.confluent.parallelconsumer</groupId>
     <artifactId>parallel-consumer-parent</artifactId>
     <name>Confluent Parallel Consumer</name>
-    <version>0.5.3.2</version>
+    <version>0.5.3.3-SNAPSHOT</version>
     <description>Parallel Apache Kafka client wrapper with client side queueing, a simpler consumer/producer API with key concurrency and extendable non-blocking IO processing.
     </description>
     <url>https://confluent.io</url>


### PR DESCRIPTION
Semaphore CI/CD task release is broken due to an uncompleted Maven prepare:release 

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-release-plugin:3.0.1:prepare (default-cli) on project parallel-consumer-parent: You don't have a SNAPSHOT project in the reactor projects list. -> [Help 1]
```

This PR fixes the pom.xml files so we can generate a new release