### PR TITLE
Fix license format

### DIFF
--- a/parallel-consumer-core/pom.xml
+++ b/parallel-consumer-core/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2020-2024 Confluent, Inc.
+    Copyright (C) 2020-2025 Confluent, Inc.
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/parallel-consumer-examples/parallel-consumer-example-core/pom.xml
+++ b/parallel-consumer-examples/parallel-consumer-example-core/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2020-2024 Confluent, Inc.
+    Copyright (C) 2020-2025 Confluent, Inc.
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/parallel-consumer-examples/parallel-consumer-example-metrics/pom.xml
+++ b/parallel-consumer-examples/parallel-consumer-example-metrics/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2020-2024 Confluent, Inc.
+    Copyright (C) 2020-2025 Confluent, Inc.
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/parallel-consumer-examples/parallel-consumer-example-reactor/pom.xml
+++ b/parallel-consumer-examples/parallel-consumer-example-reactor/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2020-2024 Confluent, Inc.
+    Copyright (C) 2020-2025 Confluent, Inc.
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/parallel-consumer-examples/parallel-consumer-example-streams/pom.xml
+++ b/parallel-consumer-examples/parallel-consumer-example-streams/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2020-2024 Confluent, Inc.
+    Copyright (C) 2020-2025 Confluent, Inc.
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/parallel-consumer-examples/parallel-consumer-example-vertx/pom.xml
+++ b/parallel-consumer-examples/parallel-consumer-example-vertx/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2020-2024 Confluent, Inc.
+    Copyright (C) 2020-2025 Confluent, Inc.
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/parallel-consumer-examples/pom.xml
+++ b/parallel-consumer-examples/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2020-2024 Confluent, Inc.
+    Copyright (C) 2020-2025 Confluent, Inc.
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/parallel-consumer-reactor/pom.xml
+++ b/parallel-consumer-reactor/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2020-2024 Confluent, Inc.
+    Copyright (C) 2020-2025 Confluent, Inc.
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/parallel-consumer-vertx/pom.xml
+++ b/parallel-consumer-vertx/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2020-2024 Confluent, Inc.
+    Copyright (C) 2020-2025 Confluent, Inc.
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">


### PR DESCRIPTION
CI/CD failed due to license format header not being up-to-date 

```
Warning: JAVA_HOME environment variable is not set.00:00
[ERROR] Failed to execute goal com.mycila:license-maven-plugin:5.0.0:check (default) on project parallel-consumer-parent: Some files do not have the expected license header. Run license:format to update them. -> [Help 1]01:09
[ERROR] 01:09
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.01:09
[ERROR] Re-run Maven using the -X switch to enable full debug logging.01:09
[ERROR] 01:09
[ERROR] For more information about the errors and possible solutions, please read the following articles:01:09
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
```