### PR TITLE
fix: trim user-function error log; move full PollContext to DEBUG (fixes #640)

### DIFF
--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/internal/AbstractParallelEoSStreamProcessor.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/internal/AbstractParallelEoSStreamProcessor.java
@@ -1351,12 +1351,23 @@ public abstract class AbstractParallelEoSStreamProcessor<K, V> implements Parall
         } catch (Exception e) {
             // handle fail
             var cause = e.getCause();
+            // Keep the primary error log line short (record count + partitions) so it stays readable
+            // when the user function throws for large batches; dumping the whole PollContext toString
+            // (which transitively prints every ConsumerRecord in the batch) tends to get truncated by
+            // downstream log tooling and can surface user-payload data inside error logs. The full
+            // context is still available at DEBUG for troubleshooting.
+            // See https://github.com/confluentinc/parallel-consumer/issues/640
+            long recordCount = context.getPollContext().size();
+            var partitions = context.getPollContext().getByTopicPartitionMap().keySet();
             String msg = msg("Exception caught in user function running stage, registering WC as failed, returning to" +
-                    " mailbox. Context: {}", context, e);
+                    " mailbox. partitions={} records={}", partitions, recordCount);
             if (cause instanceof PCRetriableException) {
                 log.debug("Explicit " + PCRetriableException.class.getSimpleName() + " caught, logging at DEBUG only. " + msg, e);
             } else {
                 log.error(msg, e);
+                if (log.isDebugEnabled()) {
+                    log.debug("Full PollContext for the failed user function batch: {}", context);
+                }
             }
 
             for (var wc : workContainerBatch) {


### PR DESCRIPTION
﻿## Motivation

Fixes #640.

`AbstractParallelEoSStreamProcessor#runUserFunction` currently logs the entire `PollContextInternal` on every user-function failure:

```java
String msg = msg("Exception caught in user function running stage, registering WC as failed, returning to" +
        " mailbox. Context: {}", context, e);
if (cause instanceof PCRetriableException) {
    log.debug("Explicit ... caught, logging at DEBUG only. " + msg, e);
} else {
    log.error(msg, e);
}
```

Two problems with this:

1. **Truncation.** `PollContextInternal` is `@ToString`d via Lombok, which transitively prints every `ConsumerRecord` in the batch. With realistic `batchSize` settings the resulting line easily exceeds the per-line budget of common log shippers (Filebeat, Fluent Bit, journald, Docker JSON driver), so the ERROR gets cut off and the stack trace below it becomes harder to correlate.

2. **Sensitive data in error logs.** The `@ToString` expansion serialises record keys and values, which can include user payloads &mdash; exactly the concern raised by @ndqvinh2109 in the thread above. Users were already working around this at log4j level by masking the log pattern.

## Modifications

Split the message into two tiers:

- **ERROR** (always emitted): a concise summary &mdash; `partitions=[...]` and `records=<count>` &mdash; using `PollContext#getByTopicPartitionMap().keySet()` and `PollContext#size()`. That's enough to correlate the failure to the right topic-partition without dragging record payloads into the error log.
- **DEBUG** (only when `log.isDebugEnabled()`): the full `PollContext` dump, so operators troubleshooting a specific failure can still see the original context by bumping the logger to `DEBUG`.

The existing `PCRetriableException` branch (which already only logs at `DEBUG`) is preserved with the shorter message, since it never went to ERROR anyway.

Added a short inline comment pointing at this issue so the rationale doesn't get lost.

## Verifying this change

Flow is unchanged (same retry / mailbox / throw semantics), only log output differs. A unit test that exercises `runUserFunction` with a throwing user function should now emit an ERROR line containing `partitions=` and `records=` and no record payload, and (if DEBUG is enabled) a second DEBUG line with the full context.

Happy to add an explicit test under `parallel-consumer-core/src/test` if you'd prefer to lock this in. Noting that my previous PR #918 for the similar #631 was already along these lines.

## Does this pull request introduce a _user-facing_ change?

- [x] Yes &mdash; log line for user-function failures is now shorter; full context moves to DEBUG.